### PR TITLE
增加账户转移(暂未写转移页面)

### DIFF
--- a/modules/user_center/actions/account.cpp
+++ b/modules/user_center/actions/account.cpp
@@ -1,4 +1,6 @@
 #include "../user_center.h"
+#define CPPHTTPLIB_OPENSSL_SUPPORT
+#include "cpp-httplib/httplib.h"
 #include "utils.h"
 #include "secrets.h"
 #include "Captcha.h"
@@ -7,102 +9,135 @@
 #include <regex>
 #include <openssl/hmac.h>
 
-static int hmac_algo_sha1(const char* byte_secret, const char* byte_string, char* out) {
+extern httplib::Client dotcsClient;
+extern httplib::Headers DotCS_Headers;
+static int hmac_algo_sha1(const char *byte_secret, const char *byte_string, char *out)
+{
 	unsigned int len = 20;
-	unsigned char* result = HMAC(EVP_sha1(),(unsigned char*)byte_secret, 10, (unsigned char*)byte_string, 8, (unsigned char*)out,&len);
+	unsigned char *result = HMAC(EVP_sha1(), (unsigned char *)byte_secret, 10, (unsigned char *)byte_string, 8, (unsigned char *)out, &len);
 	return result == 0 ? 0 : len;
 }
 
-static uint64_t get_current_time() {
+static uint64_t get_current_time()
+{
 	using namespace std::chrono;
 	auto now = system_clock::now();
 	auto dur = now.time_since_epoch();
 	return duration_cast<std::chrono::seconds>(dur).count();
 }
 
-namespace FBUC {
+namespace FBUC
+{
 	ACTION2(APIListAction, "api",
 			std::optional<std::string>, with_prefix, "with_prefix",
-			std::optional<std::string>, jump_to, "jump_to") {
-		std::string prefix=with_prefix->has_value()?**with_prefix:"";
-		struct ActionResult result={true, "ok"};
-		bool include_login_only=(bool)session->user;
-		for(auto const &i:fbuc_actions) {
-			if(include_login_only||!i.second->mandatory_login()) {
-				result.additional_items[i.second->action_name]=fmt::format("{}/api/{}", prefix, i.second->action_name);
+			std::optional<std::string>, jump_to, "jump_to")
+	{
+		std::string prefix = with_prefix->has_value() ? **with_prefix : "";
+		struct ActionResult result = {true, "ok"};
+		bool include_login_only = (bool)session->user;
+		for (auto const &i : fbuc_actions)
+		{
+			if (include_login_only || !i.second->mandatory_login())
+			{
+				result.additional_items[i.second->action_name] = fmt::format("{}/api/{}", prefix, i.second->action_name);
 			}
 		}
-		if(jump_to->has_value()) {
-			if(result.additional_items[**jump_to]) {
+		if (jump_to->has_value())
+		{
+			if (result.additional_items[**jump_to])
+			{
 				throw RedirectDemand{result.additional_items[**jump_to].asString()};
-			}else{
+			}
+			else
+			{
 				return {false, "No such entry to jump to."};
 			}
 		}
-		if(session->user&&session->user->isAdministrator) {
+		if (session->user && session->user->isAdministrator)
+		{
 			Json::Value ext_map;
-			for(auto const &i:fbuc_administrative_actions) {
-				ext_map[i.second->action_name]=fmt::format("{}/api/administrative/{}", prefix, i.second->action_name);
+			for (auto const &i : fbuc_administrative_actions)
+			{
+				ext_map[i.second->action_name] = fmt::format("{}/api/administrative/{}", prefix, i.second->action_name);
 			}
-			result.additional_items["ext"]=ext_map;
+			result.additional_items["ext"] = ext_map;
 		}
-		if(session->user) {
-			result.additional_items["username"]=*session->user->username;
-			result.additional_items["theme"]=session->user->preferredtheme.has_value()?*session->user->preferredtheme:"bootstrap";
+		if (session->user)
+		{
+			result.additional_items["username"] = *session->user->username;
+			result.additional_items["is_DotCS"] = *session->user->isDotCS;
+			result.additional_items["DotCS_User_Name"] = *session->user->DotCS_User_Name;
+			result.additional_items["theme"] = session->user->preferredtheme.has_value() ? *session->user->preferredtheme : "bootstrap";
 		}
 		return result;
 	}
-	
+
 	ACTION4(LoginAction, "login",
 			std::optional<std::string>, _username, "username",
 			std::optional<std::string>, _password, "password",
 			std::string, mfa_code, "mfa_code",
-			std::optional<std::string>, token, "token") {
-		if(session->user) {
+			std::optional<std::string>, token, "token")
+	{
+		if (session->user)
+		{
 			throw InvalidRequestDemand{"Already logged in"};
 		}
 		std::string username;
 		std::string password;
-		bool is_token_login=false;
-		if(!token->has_value()) {
-			if(!_username->has_value()||!_password->has_value()) {
+		bool is_token_login = false;
+		if (!token->has_value())
+		{
+			if (!_username->has_value() || !_password->has_value())
+			{
 				throw InvalidRequestDemand{"Insufficient arguments"};
 			}
-			username=**_username;
-			password=Utils::sha256(Secrets::addSalt(**_password));
-		}else{
-			is_token_login=true;
-			if(_username->has_value()) {
+			username = **_username;
+			password = Utils::sha256(Secrets::addSalt(**_password));
+		}
+		else
+		{
+			is_token_login = true;
+			if (_username->has_value())
+			{
 				throw InvalidRequestDemand{"Conflicted arguments"};
 			}
 			Json::Value token_content;
-			bool parsed=Utils::parseJSON(FBToken::decrypt(**token), &token_content, nullptr);
-			if(!parsed||!token_content["username"].isString()||!token_content["password"].isString()||!token_content["newToken"].asBool()) {
+			bool parsed = Utils::parseJSON(FBToken::decrypt(**token), &token_content, nullptr);
+			if (!parsed || !token_content["username"].isString() || !token_content["password"].isString() || !token_content["newToken"].asBool())
+			{
 				return {false, "Invalid token"};
 			}
-			username=token_content["username"].asString();
-			password=token_content["password"].asString();
+			username = token_content["username"].asString();
+			password = token_content["password"].asString();
 		}
-		std::shared_ptr<FBWhitelist::User> pUser=FBWhitelist::Whitelist::acquireUser(username);
-		if(!pUser||pUser->password!=password) {
+		std::shared_ptr<FBWhitelist::User> pUser = FBWhitelist::Whitelist::acquireUser(username);
+		if (!pUser || pUser->password != password)
+		{
 			SPDLOG_INFO("User Center login (rejected): Username: {}, IP: {}", username, session->ip_address);
 			return {false, "Invalid username, password, or MFA code."};
 		}
-		if(!pUser->disable_all_security_measures) {
-			if(pUser->two_factor_authentication_secret.has_value()&&pUser->two_factor_authentication_secret->length()!=15) {
-				if(mfa_code->length()!=6) {
+		if (!pUser->disable_all_security_measures)
+		{
+			if (pUser->two_factor_authentication_secret.has_value() && pUser->two_factor_authentication_secret->length() != 15)
+			{
+				if (mfa_code->length() != 6)
+				{
 					SPDLOG_INFO("User Center login (rejected): Username: {}, IP: {}", username, session->ip_address);
 					return {false, "Invalid username, password, or MFA code."};
 				}
 				char secret[17];
 				OTPData data;
 				totp_new(&data, pUser->two_factor_authentication_secret->c_str(), hmac_algo_sha1, get_current_time, 6, 30);
-				int val=totp_verify(&data, mfa_code->c_str(), time(nullptr), 2);
-				if(!val) {
+				int val = totp_verify(&data, mfa_code->c_str(), time(nullptr), 2);
+				if (!val)
+				{
 					return {false, "Invalid username, password, or MFA code."};
 				}
-			}else{
-				if(is_token_login||mfa_code->length()!=0) {
+			}
+			else
+			{
+				if (is_token_login || mfa_code->length() != 0)
+				{
 					// 1. Token login but no MFA set
 					// 2. No MFA set but requester gives a MFA
 					SPDLOG_INFO("User Center login (rejected): Username: {}, IP: {}", username, session->ip_address);
@@ -110,213 +145,474 @@ namespace FBUC {
 				}
 			}
 		}
-		FBWhitelist::User *rawUser=pUser.get();
-		if(user_unique_map.contains(rawUser)) {
+
+		FBWhitelist::User *rawUser = pUser.get();
+		if (user_unique_map.contains(rawUser))
+		{
 			userlist_mutex.lock();
 			userlist.erase(user_unique_map[rawUser]);
-			user_unique_map[rawUser]=session->session_id;
-			userlist_mutex.unlock();
-		}else{
-			userlist_mutex.lock();
-			user_unique_map[rawUser]=session->session_id;
+			user_unique_map[rawUser] = session->session_id;
 			userlist_mutex.unlock();
 		}
-		session->user=pUser;
-		std::string user_theme=pUser->preferredtheme.has_value()?(*pUser->preferredtheme):"bootstrap";
-		session->token_login=token->has_value();
-		session->phoenix_only=false;
-		*pUser->keep_reference=true;
-		SPDLOG_INFO("User Center login (passed): Username: {}, IP: {}", username, session->ip_address);
-		return {true, "Welcome", "theme", user_theme, "isadmin", *pUser->isAdministrator};
+		else
+		{
+			userlist_mutex.lock();
+			user_unique_map[rawUser] = session->session_id;
+			userlist_mutex.unlock();
+		}
+		if (*pUser->isDotCS)
+		{
+			SPDLOG_INFO("User Center login (rejected-dotcs): Username: {}, IP: {}", username, session->ip_address);
+			return {false, "此账户已绑定 DotCS,请使用 DotCS 账户登录。"};
+		}
+		else
+		{
+			session->user = pUser;
+			std::string user_theme = pUser->preferredtheme.has_value() ? (*pUser->preferredtheme) : "bootstrap";
+			session->token_login = token->has_value();
+			session->phoenix_only = false;
+			*pUser->keep_reference = true;
+			SPDLOG_INFO("User Center login (passed): Username: {}, IP: {}", username, session->ip_address);
+			return {true, "Welcome", "theme", user_theme, "isadmin", *pUser->isAdministrator};
+		}
 	}
-	
-	ACTION0(CaptchaAction, "captcha") {
+	ACTION2(Login_DotCS_Action, "login_dotcs",
+			std::optional<std::string>, _username, "username",
+			std::optional<std::string>, _password, "password")
+	{
+		if (!_username->has_value() || !_password->has_value())
+		{
+			throw InvalidRequestDemand{"Insufficient arguments"};
+		}
+		std::string username;
+		std::string password;
+		if (session->user)
+		{
+			throw InvalidRequestDemand{"Already logged in"};
+		}
+		username = **_username;
+		password = **_password;
+		Json::Value login_packet;
+		login_packet["username"] = username;
+		login_packet["password"] = password;
+
+		Json::StreamWriterBuilder writebuild;
+		writebuild["emitUTF8"] = true;
+		std::string login_text = Json::writeString(writebuild, login_packet);
+		if (auto res = dotcsClient.Post("/fbuc_api/fb_user_login", DotCS_Headers, login_text, "application/json"))
+		{
+			if (res->status == 200)
+			{
+
+				Json::CharReaderBuilder ReaderBuilder;
+				ReaderBuilder["emitUTF8"] = true;
+				std::unique_ptr<Json::CharReader> charread(ReaderBuilder.newCharReader());
+				std::string data = res->body;
+				Json::Value root;
+				std::string strerr;
+				bool isok = charread->parse(data.c_str(), data.c_str() + data.size(), &root, &strerr);
+				if (!isok || strerr.size() != 0)
+				{
+					return {false, "DotCS验证服务器的消息解析失败,可能是DotCS服务器未开启此接口。"};
+				}
+				bool success = root.get("success", false).asBool();
+				if (success == true)
+				{
+					std::string fb_username = root.get("fb_name", "").asString();
+					if (fb_username == "")
+					{
+						return {false, "FastBuilder未能成功获取到DotCS用户信息,请联系 DotCS 解决。"};
+					}
+					std::shared_ptr<FBWhitelist::User> pUser = FBWhitelist::Whitelist::acquireUser(fb_username);
+					if (!pUser)
+					{
+						SPDLOG_INFO("User Center login (rejected-dotcs): Username: {}, IP: {}", fb_username, session->ip_address);
+						return {false, "无效的FastBuilder账户"};
+					}
+					else if (pUser->DotCS_User_Name != username)
+					{
+						SPDLOG_INFO("User Center login (rejected-dotcs): Username: {}, IP: {}", fb_username, session->ip_address);
+						return {false, "此账户绑定的FastBuilder用户名与FastBuilder所记载的不一致。如果您的DotCS用户名或FastBuilder用户名被更改了,可联系另一个平台的管理员进行更正"};
+					}
+					if (!pUser->isDotCS)
+					{
+						SPDLOG_INFO("User Center login (rejected-dotcs): Username: {}, IP: {}", fb_username, session->ip_address);
+						return {false, "此账户在FastBuilder的记录中尚未绑定,请联系FastBuilder管理员进行绑定。"};
+					}
+					else
+					{
+						FBWhitelist::User *rawUser = pUser.get();
+						if (user_unique_map.contains(rawUser))
+						{
+							userlist_mutex.lock();
+							userlist.erase(user_unique_map[rawUser]);
+							user_unique_map[rawUser] = session->session_id;
+							userlist_mutex.unlock();
+						}
+						else
+						{
+							userlist_mutex.lock();
+							user_unique_map[rawUser] = session->session_id;
+							userlist_mutex.unlock();
+						}
+						session->user = pUser;
+						std::string user_theme = pUser->preferredtheme.has_value() ? (*pUser->preferredtheme) : "bootstrap";
+						session->token_login = false;
+						session->phoenix_only = false;
+						*pUser->keep_reference = true;
+						SPDLOG_INFO("User Center login (passed-dotcs): Username: {}, IP: {}", fb_username, session->ip_address);
+						return {true, "Welcome", "theme", user_theme, "isadmin", *pUser->isAdministrator};
+					}
+				}
+				else
+				{
+					return {false, root.get("message", "未知DotCS验证服务器错误").asString()};
+				}
+			}
+			else
+			{
+				return {false, "DotCS验证服务器无法服务或验证未通过"};
+			}
+		}
+		else
+		{
+			return {false, "DotCS验证服务器暂时无法访问,请等待恢复"};
+		}
+	}
+
+	ACTION0(CaptchaAction, "captcha")
+	{
 		std::vector<uint8_t> buf;
 		std::string the_captcha;
-		if(generateCaptcha(buf, the_captcha)!=0) {
+		if (generateCaptcha(buf, the_captcha) != 0)
+		{
 			throw ServerErrorDemand{"Unknown error"};
 		}
-		session->last_captcha=the_captcha;
-		throw DirectReturnDemand {
+		session->last_captcha = the_captcha;
+		throw DirectReturnDemand{
 			std::string((const char *)&buf.front(), buf.size()),
-			"image/png"
-		};
+			"image/png"};
 	}
-	
-	LACTION0(LogoutAction, "logout") {
+
+	LACTION0(LogoutAction, "logout")
+	{
 		userlist_mutex.lock();
-		*session->user->keep_reference=false;
+		*session->user->keep_reference = false;
 		user_unique_map.erase(session->user.get());
 		userlist.erase(session->session_id);
 		userlist_mutex.unlock();
 		return {true, "OK"};
 	}
-	
-	LACTION0(FetchProfileAction, "fetch_profile") {
-		FBWhitelist::User &user=*session->user;
-		std::string blc="机器人绑定码在 Token 登录状态下不能被显示。";
-		if(!session->token_login) {
-			blc=fmt::format("v|{}!{}", *(user.username), Utils::sha256(Secrets::add_external_bot_salt(user.username)));
+
+	LACTION0(FetchProfileAction, "fetch_profile")
+	{
+		FBWhitelist::User &user = *session->user;
+		std::string blc = "机器人绑定码在 Token 登录状态下不能被显示。";
+		bool is_can_show_blc = true;
+		bool is_hidden_by_default_blc = true;
+		if (session->user->isDotCS)
+		{
+			is_can_show_blc = false;
+			is_hidden_by_default_blc = false;
+			blc = "由于 DotCS 的安全机制,您不得使用机器人绑定码做任何事情。";
 		}
-		std::string cn_username=user.cn_username.has_value()?*(user.cn_username):"";
-		Json::Value slots=user.rentalservers.toDescriptiveJSON();
-		bool is_2fa=user.two_factor_authentication_secret.has_value();
+		else if (!session->token_login)
+		{
+			is_hidden_by_default_blc = false;
+			blc = fmt::format("v|{}!{}", *(user.username), Utils::sha256(Secrets::add_external_bot_salt(user.username)));
+		}
+		Json::Value jsonArray(Json::arrayValue);
+		Json::Value DotCS_License = jsonArray;
+		std::string cn_username = user.cn_username.has_value() ? *(user.cn_username) : "";
+		Json::Value slots;
+		if (session->user->isDotCS)
+		{	
+			Json::Value jsonArray(Json::arrayValue);
+			slots = jsonArray;
+		}
+		else
+		{
+			slots = user.rentalservers.toDescriptiveJSON();
+		}
+		bool is_2fa = user.two_factor_authentication_secret.has_value();
 		float mp_duration;
-		if(!session->user->free) {
-			mp_duration=-1;
-		}else if(!session->user->expiration_date.stillAlive()) {
-			mp_duration=0;
-		}else{
-			mp_duration=round(((session->user->expiration_date-time(nullptr))/86400.00)*100.0)/100.0;
+		if (session->user->isDotCS)
+		{
+			mp_duration = -1;
+			Json::Value login_packet;
+			login_packet["username"] = session->user->DotCS_User_Name;
+			Json::StreamWriterBuilder writebuild;
+			writebuild["emitUTF8"] = true;
+			std::string login_text = Json::writeString(writebuild, login_packet);
+			if (auto res = dotcsClient.Post("/fbuc_api/fb_user_license_list", DotCS_Headers, login_text, "application/json"))
+			{
+				if (res->status == 200)
+				{
+
+					Json::CharReaderBuilder ReaderBuilder;
+					ReaderBuilder["emitUTF8"] = true;
+					std::unique_ptr<Json::CharReader> charread(ReaderBuilder.newCharReader());
+					std::string data = res->body;
+					Json::Value root;
+					std::string strerr;
+					bool isok = charread->parse(data.c_str(), data.c_str() + data.size(), &root, &strerr);
+					if (!isok || strerr.size() != 0)
+					{
+						Json::Value jsonArray(Json::arrayValue);
+						Json::Value error_tip_license;
+						error_tip_license["name"] = "获取失败";
+						error_tip_license["data"] = "DotCS验证服务器的消息解析失败,可能是DotCS服务器未开启此接口";
+						DotCS_License = jsonArray;
+					} else {
+						bool success = root.get("success", false).asBool();
+						if (success == true)
+						{
+							DotCS_License = root.get("license", "[]");
+						}
+						else
+						{
+							Json::Value jsonArray(Json::arrayValue);
+							Json::Value error_tip_license;
+							error_tip_license["name"] = "获取失败";
+							error_tip_license["data"] = "未知DotCS验证服务器错误";
+							DotCS_License = jsonArray;
+						}
+					}
+
+				}
+				else
+				{
+					Json::Value jsonArray(Json::arrayValue);
+					Json::Value error_tip_license;
+					error_tip_license["name"] = "获取失败";
+					error_tip_license["data"] = "DotCS验证服务器无法服务或验证未通过";
+					DotCS_License = jsonArray;
+				}
+			}
+			else
+			{
+				Json::Value jsonArray(Json::arrayValue);
+				Json::Value error_tip_license;
+				error_tip_license["name"] = "获取失败";
+				error_tip_license["data"] = "DotCS验证服务器暂时无法访问,请等待恢复";
+				DotCS_License = jsonArray;
+			}
 		}
-		int32_t user_points=session->user->points.has_value()?session->user->points:0;
-		if(!user.phoenix_login_otp.has_value()) {
-			user.phoenix_login_otp=Utils::generateUUID();
+		else
+		{
+
+			if (!session->user->free)
+			{
+				mp_duration = -1;
+			}
+			else if (!session->user->expiration_date.stillAlive())
+			{
+				mp_duration = 0;
+			}
+			else
+			{
+				mp_duration = round(((session->user->expiration_date - time(nullptr)) / 86400.00) * 100.0) / 100.0;
+			}
 		}
-		std::string phoenix_otp=user.phoenix_login_otp;
-		return {true, "Well done", "blc", blc, "cn_username", cn_username, "slots", slots, "is_2fa", is_2fa, "monthly_plan_duration", mp_duration, "points", user_points, "nemcbind_status", session->user->nemc_binded_account.has_value(), "phoenix_otp", phoenix_otp, "no_security", (bool)user.disable_all_security_measures};
+		int32_t user_points = session->user->points.has_value() ? session->user->points : 0;
+		if (!user.phoenix_login_otp.has_value())
+		{
+			user.phoenix_login_otp = Utils::generateUUID();
+		}
+		std::string phoenix_otp = user.phoenix_login_otp;
+		return {true, "Well done", // 是否成功,消息
+								   // 下面的就是各种键值了,例如下面的 ` "blc",blc ` 表示的是 "blc":blc (json 表达)
+				"is_dotcs", (bool)session->user->isDotCS,
+				"dotcs_username", session->user->DotCS_User_Name,
+				"blc", blc,
+				"is_can_show_blc", is_can_show_blc,
+				"is_hidden_by_default_blc", is_hidden_by_default_blc,
+				"cn_username", cn_username,
+				"slots", slots,
+				"is_2fa", is_2fa,
+				"monthly_plan_duration", mp_duration,
+				"license", DotCS_License,
+				"points", user_points,
+				"nemcbind_status", session->user->nemc_binded_account.has_value(),
+				"phoenix_otp", phoenix_otp,
+				"no_security", (bool)user.disable_all_security_measures};
 	}
-	
 	LACTION1(SaveClientUsernameAction, "save_client_username",
-			std::string, username, "cnun") {
-		if(username->length()>32) {
+			 std::string, username, "cnun")
+	{
+		if (username->length() > 32)
+		{
 			return {false, "用户名太长"};
 		}
-		session->user->cn_username=*username;
+		session->user->cn_username = *username;
 		return {true, "", "username", *username};
 	}
-	
+
 	LACTION3(SaveSlotAction, "save_slot",
-			std::string, slotid, "slotid",
-			std::optional<std::string>, content, "content",
-			std::optional<std::string>, operation, "operation") {
-		FBWhitelist::User *user=session->user.get();
-		if(!user->rentalservers.size()) {
+			 std::string, slotid, "slotid",
+			 std::optional<std::string>, content, "content",
+			 std::optional<std::string>, operation, "operation")
+	{
+		FBWhitelist::User *user = session->user.get();
+		if (!user->rentalservers.size())
+		{
 			throw InvalidRequestDemand{"NO WAY"};
 		}
-		auto &slot=user->rentalservers[slotid];
-		if(!slot) {
+		auto &slot = user->rentalservers[slotid];
+		if (!slot)
+		{
 			return {false, "内部错误: slotid 无效"};
 		}
-		if(!content->has_value()&&**operation!="remove") {
+		if (!content->has_value() && **operation != "remove")
+		{
 			throw InvalidRequestDemand{"Invalid request"};
 		}
-		if(**operation!="remove") {
-			std::string scontent=**content;
-			if(scontent.length()>16||scontent.length()<4) {
+		if (**operation != "remove")
+		{
+			std::string scontent = **content;
+			if (scontent.length() > 16 || scontent.length() < 4)
+			{
 				return {false, "过于夸张的租赁服号长度"};
 			}
-			uint32_t val=0;
-			try {
-				val=std::stoi(scontent);
-			}catch(...) {
+			uint32_t val = 0;
+			try
+			{
+				val = std::stoi(scontent);
+			}
+			catch (...)
+			{
 				return {false, "无效租赁服号"};
 			}
-			if(slot.lastdate) {
-				if(slot.locked) {
+			if (slot.lastdate)
+			{
+				if (slot.locked)
+				{
 					return {false, "不可以更改已经写入的固定 slot"};
 				}
-				time_t sugosu=time(nullptr)-slot.lastdate;
-				if(sugosu<=2592000) {
-					float ato=round(((2592000-sugosu)/86400.0)*100.0)/100.0;
+				time_t sugosu = time(nullptr) - slot.lastdate;
+				if (sugosu <= 2592000)
+				{
+					float ato = round(((2592000 - sugosu) / 86400.0) * 100.0) / 100.0;
 					return {false, fmt::format("{} 天之后方可修改此 slot", ato)};
 				}
 			}
-			slot.lastdate=time(nullptr);
-			slot.content=scontent;
+			slot.lastdate = time(nullptr);
+			slot.content = scontent;
 			return {true, "Well done", "slots", user->rentalservers.toDescriptiveJSON()};
-		}else{
+		}
+		else
+		{
 			user->rentalservers.erase_slot(slotid);
 			return {true, "ok", "slots", user->rentalservers.toDescriptiveJSON()};
 		}
 	}
-	
+
 	LACTION2(ChangePasswordAction, "change_password",
-			std::string, originalPassword, "originalPassword",
-			std::string, newPassword, "newPassword") {
-		if(session->token_login&&!session->user->disable_all_security_measures) {
-			throw InvalidRequestDemand{"Changing password is forbidden for token-login users."};
+			 std::string, originalPassword, "originalPassword",
+			 std::string, newPassword, "newPassword")
+	{
+		if (!session->user->isDotCS){
+			if (session->token_login && !session->user->disable_all_security_measures)
+			{
+				throw InvalidRequestDemand{"Changing password is forbidden for token-login users."};
+			}
+			if (originalPassword->length() != 64 || newPassword->length() != 64 || newPassword == "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
+			{
+				throw InvalidRequestDemand{"Invalid Request"};
+			}
+			FBWhitelist::User *user = session->user.get();
+			if (user->password != Utils::sha256(Secrets::addSalt(*originalPassword)))
+			{
+				return {false, "原密码不正确"};
+			}
+			user->password = Utils::sha256(Secrets::addSalt(newPassword));
+			return {true, "ok"};
+		} else {
+			return {false, "你没有权限修改密码"};
 		}
-		if(originalPassword->length()!=64||newPassword->length()!=64||newPassword=="e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855") {
-			throw InvalidRequestDemand{"Invalid Request"};
-		}
-		FBWhitelist::User *user=session->user.get();
-		if(user->password!=Utils::sha256(Secrets::addSalt(*originalPassword))) {
-			return {false, "原密码不正确"};
-		}
-		user->password=Utils::sha256(Secrets::addSalt(newPassword));
-		return {true, "ok"};
 	}
-	
-	LACTION0(GetThemeInfoAction, "get_theme_info") {
+
+	LACTION0(GetThemeInfoAction, "get_theme_info")
+	{
 		return {true, "", "data", *session->user->preferredtheme};
 	}
-	
+
 	LACTION1(ApplyThemeAction, "apply_theme",
-			std::string, theme, "name") {
-		if(theme->size()<2||theme->size()>32) {
+			 std::string, theme, "name")
+	{
+		if (theme->size() < 2 || theme->size() > 32)
+		{
 			throw InvalidRequestDemand{"Invalid theme string given"};
 		}
-		session->user->preferredtheme=theme;
+		session->user->preferredtheme = theme;
 		return {true};
 	}
-	
+
 	ACTION3(RegisterAction, "register",
 			std::string, username, "username",
 			std::string, password, "password",
-			std::string, captcha, "captcha") {
-		if(password->length()!=64)
+			std::string, captcha, "captcha")
+	{
+		if (password->length() != 64)
 			throw InvalidRequestDemand{"Invalid request"};
-		if(!session->verifyCaptcha(captcha)) {
+		if (!session->verifyCaptcha(captcha))
+		{
 			return {false, "验证码不正确"};
 		}
 		std::regex username_req("^[A-Za-z0-9]+$", std::regex_constants::ECMAScript);
 		std::smatch matching_buf;
-		std::string perm_un=*username;
-		if(!std::regex_match(perm_un, matching_buf, username_req)) {
+		std::string perm_un = *username;
+		if (!std::regex_match(perm_un, matching_buf, username_req))
+		{
 			return {false, "无效用户名"};
 		}
-		if(password=="2dcc453c31b52d2b1137e0d02e823d64dbf3c722551c545e8889d8e45f54fa32")
+		if (password == "2dcc453c31b52d2b1137e0d02e823d64dbf3c722551c545e8889d8e45f54fa32")
 			return {false, "无效密码"};
-		if(FBWhitelist::Whitelist::acquireUser(username))
+		if (FBWhitelist::Whitelist::acquireUser(username))
 			return {false, "用户名被占用"};
-		std::optional<FBWhitelist::User> user=FBWhitelist::Whitelist::createUser(username, Utils::sha256(Secrets::addSalt(password)));
-		if(!user.has_value()) {
+		std::optional<FBWhitelist::User> user = FBWhitelist::Whitelist::createUser(username, Utils::sha256(Secrets::addSalt(password)));
+		if (!user.has_value())
+		{
 			throw ServerErrorDemand{"Unknown exception"};
 		}
-		*user->keep_reference=true;
-		session->user=std::make_shared<FBWhitelist::User>(*user);
-		session->token_login=false;
-		session->phoenix_only=false;
+		*user->keep_reference = true;
+		session->user = std::make_shared<FBWhitelist::User>(*user);
+		session->token_login = false;
+		session->phoenix_only = false;
 		SPDLOG_INFO("User Center register: Username: {}, IP: {}", *username, session->ip_address);
 		return {true};
 	}
-	
-	LACTION0(Kickstart2FAAction, "kickstart_2fa") {
-		if(session->user->disable_all_security_measures)
+
+	LACTION0(Kickstart2FAAction, "kickstart_2fa")
+	{
+		if (session->user->disable_all_security_measures)
 			throw InvalidRequestDemand{"User is forbidden from enabling 2FA"};
-		if(session->user->two_factor_authentication_secret.has_value()) {
+		if (session->user->two_factor_authentication_secret.has_value())
+		{
 			throw InvalidRequestDemand{"User already under 2FA"};
 		}
-		OTPDataPack *otpdata=new OTPDataPack;
-		otpdata->secret[16]=0;
+		OTPDataPack *otpdata = new OTPDataPack;
+		otpdata->secret[16] = 0;
 		otp_random_base32(16, otpdata->secret);
-		session->tmp_otp=std::shared_ptr<OTPDataPack>(otpdata);
+		session->tmp_otp = std::shared_ptr<OTPDataPack>(otpdata);
 		totp_new(&(otpdata->data), otpdata->secret, hmac_algo_sha1, get_current_time, 6, 30);
-		char out[256]={0};
+		char out[256] = {0};
 		otpuri_build_uri(&(otpdata->data), "FastBuilder", session->user->username->c_str(), "SHA1", out);
 		QRCode qrcode;
 		uint8_t qrcodeBytes[qrcode_getBufferSize(4)];
 		qrcode_initText(&qrcode, qrcodeBytes, 4, ECC_LOW, out);
-		cv::Mat qr_image=cv::Mat::zeros(qrcode.size, qrcode.size, CV_8UC3);
-		qr_image=cv::Scalar(255,255,255,255);
-		for(uint8_t y=0;y<qrcode.size;y++) {
-			for(uint8_t x=0;x<qrcode.size;x++) {
-				if(qrcode_getModule(&qrcode, x, y)) {
-					cv::Vec3b &s=qr_image.at<cv::Vec3b>(cv::Point(x,y));
-					s[0]=0;
-					s[1]=0;
-					s[2]=0;
+		cv::Mat qr_image = cv::Mat::zeros(qrcode.size, qrcode.size, CV_8UC3);
+		qr_image = cv::Scalar(255, 255, 255, 255);
+		for (uint8_t y = 0; y < qrcode.size; y++)
+		{
+			for (uint8_t x = 0; x < qrcode.size; x++)
+			{
+				if (qrcode_getModule(&qrcode, x, y))
+				{
+					cv::Vec3b &s = qr_image.at<cv::Vec3b>(cv::Point(x, y));
+					s[0] = 0;
+					s[1] = 0;
+					s[2] = 0;
 				}
 			}
 		}
@@ -326,53 +622,58 @@ namespace FBUC {
 		cv::imencode(".png", larger_qr_image, out_buf);
 		return {true, "ok", "plainkey", std::string(otpdata->secret), "qrcode", fmt::format("data:image/png;base64,{}", Utils::base64Encode(std::string((const char *)&out_buf.front(), out_buf.size())))};
 	}
-	
+
 	LACTION1(FinishRegistering2FAAction, "finish_registering_2fa",
-			std::string, code, "code") {
-		if(!session->tmp_otp) {
+			 std::string, code, "code")
+	{
+		if (!session->tmp_otp)
+		{
 			throw InvalidRequestDemand{"Invalid request"};
 		}
-		int val=totp_verify(&session->tmp_otp->data, code->c_str(), time(nullptr), 2);
-		if(!val) {
+		int val = totp_verify(&session->tmp_otp->data, code->c_str(), time(nullptr), 2);
+		if (!val)
+		{
 			char wanted[7];
-			wanted[6]=0;
+			wanted[6] = 0;
 			totp_now(&session->tmp_otp->data, wanted);
-			session->tmp_otp=nullptr;
+			session->tmp_otp = nullptr;
 			return {false, fmt::format("无效验证码, 预期值: {}", wanted)};
 		}
-		session->user->two_factor_authentication_secret=std::string(session->tmp_otp->secret);
-		session->tmp_otp=nullptr;
+		session->user->two_factor_authentication_secret = std::string(session->tmp_otp->secret);
+		session->tmp_otp = nullptr;
 		return {true, "ok"};
 	}
-	
-	LACTION0(Retract2FAAction, "retract_2fa") {
-		if(!session->user->two_factor_authentication_secret.has_value()) {
+
+	LACTION0(Retract2FAAction, "retract_2fa")
+	{
+		if (!session->user->two_factor_authentication_secret.has_value())
+		{
 			throw InvalidRequestDemand{"Invalid request"};
 		}
 		session->user->two_factor_authentication_secret.unset();
 		return {true};
 	}
-	
-	LACTION0(DisableAllSecurityMeasuresAction, "disable_all_security_measures") {
-		session->user->disable_all_security_measures=true;
+
+	LACTION0(DisableAllSecurityMeasuresAction, "disable_all_security_measures")
+	{
+		session->user->disable_all_security_measures = true;
 		return {true};
 	}
-	
-	static FBUCActionCluster accountGeneralActions(0, {
-		Action::enmap(new APIListAction),
-		Action::enmap(new LoginAction),
-		Action::enmap(new CaptchaAction),
-		Action::enmap(new LogoutAction),
-		Action::enmap(new FetchProfileAction),
-		Action::enmap(new SaveClientUsernameAction),
-		Action::enmap(new SaveSlotAction),
-		Action::enmap(new ChangePasswordAction),
-		Action::enmap(new GetThemeInfoAction),
-		Action::enmap(new ApplyThemeAction),
-		Action::enmap(new RegisterAction),
-		Action::enmap(new Kickstart2FAAction),
-		Action::enmap(new FinishRegistering2FAAction),
-		Action::enmap(new Retract2FAAction),
-		Action::enmap(new DisableAllSecurityMeasuresAction)
-	});
+
+	static FBUCActionCluster accountGeneralActions(0, {Action::enmap(new APIListAction),
+													   Action::enmap(new LoginAction),
+													   Action::enmap(new Login_DotCS_Action),
+													   Action::enmap(new CaptchaAction),
+													   Action::enmap(new LogoutAction),
+													   Action::enmap(new FetchProfileAction),
+													   Action::enmap(new SaveClientUsernameAction),
+													   Action::enmap(new SaveSlotAction),
+													   Action::enmap(new ChangePasswordAction),
+													   Action::enmap(new GetThemeInfoAction),
+													   Action::enmap(new ApplyThemeAction),
+													   Action::enmap(new RegisterAction),
+													   Action::enmap(new Kickstart2FAAction),
+													   Action::enmap(new FinishRegistering2FAAction),
+													   Action::enmap(new Retract2FAAction),
+													   Action::enmap(new DisableAllSecurityMeasuresAction)});
 };

--- a/modules/user_center/actions/db_related.cpp
+++ b/modules/user_center/actions/db_related.cpp
@@ -22,367 +22,466 @@ using bsoncxx::builder::stream::open_document;
 
 extern mongocxx::pool mongodb_pool;
 
-namespace FBUC {
+namespace FBUC
+{
 	LACTION2(VoteAnnouncementAction, "vote_announcement",
-			std::string, vote_type, "vote_type",
-			std::string, uniqueId, "unique_id") {
-		if(vote_type!="up"&&vote_type!="down")
+			 std::string, vote_type, "vote_type",
+			 std::string, uniqueId, "unique_id")
+	{
+		if (vote_type != "up" && vote_type != "down")
 			throw InvalidRequestDemand{"无效投票类型"};
-		FBWhitelist::User *user=session->user.get();
-		auto client=mongodb_pool.acquire();
-		auto fbdb=(*client)["fastbuilder"];
-		auto _target_announcement=fbdb["announcements"].find_one(document{}<<"uniqueId"<<*uniqueId<<finalize);
-		if(!_target_announcement.has_value()) {
+		FBWhitelist::User *user = session->user.get();
+		auto client = mongodb_pool.acquire();
+		auto fbdb = (*client)["fastbuilder"];
+		auto _target_announcement = fbdb["announcements"].find_one(document{} << "uniqueId" << *uniqueId << finalize);
+		if (!_target_announcement.has_value())
+		{
 			return {false, "公告不存在"};
 		}
-		auto target_announcement=*_target_announcement;
-		if(vote_type=="up") {
-			if(target_announcement["downvoters"]) {
-				auto downvoters_arr=target_announcement["downvoters"].get_array();
-				for(auto i:downvoters_arr.value) {
-					if(user->user_oid==(std::string)i.get_string()) {
+		auto target_announcement = *_target_announcement;
+		if (vote_type == "up")
+		{
+			if (target_announcement["downvoters"])
+			{
+				auto downvoters_arr = target_announcement["downvoters"].get_array();
+				for (auto i : downvoters_arr.value)
+				{
+					if (user->user_oid == (std::string)i.get_string())
+					{
 						return {false, "你已经投过反对票了，不能投支持票。"};
 					}
 				}
 			}
-			size_t orig_upvoters=target_announcement["upvoters"]?std::distance(target_announcement["upvoters"].get_array().value.begin(),target_announcement["upvoters"].get_array().value.end()):0;
-			auto pull_result=fbdb["announcements"].update_one(document{}<<"_id"<<target_announcement["_id"].get_oid()<<finalize, document{}<<"$pull"<<open_document<<"upvoters"<<user->user_oid<<close_document<<finalize);
-			if(!pull_result->modified_count()) {
+			size_t orig_upvoters = target_announcement["upvoters"] ? std::distance(target_announcement["upvoters"].get_array().value.begin(), target_announcement["upvoters"].get_array().value.end()) : 0;
+			auto pull_result = fbdb["announcements"].update_one(document{} << "_id" << target_announcement["_id"].get_oid() << finalize, document{} << "$pull" << open_document << "upvoters" << user->user_oid << close_document << finalize);
+			if (!pull_result->modified_count())
+			{
 				orig_upvoters++;
-				fbdb["announcements"].update_one(document{}<<"_id"<<target_announcement["_id"].get_oid()<<finalize, document{}<<"$push"<<open_document<<"upvoters"<<user->user_oid<<close_document<<finalize);
-			}else{
+				fbdb["announcements"].update_one(document{} << "_id" << target_announcement["_id"].get_oid() << finalize, document{} << "$push" << open_document << "upvoters" << user->user_oid << close_document << finalize);
+			}
+			else
+			{
 				orig_upvoters--;
 			}
 			Json::Value update_val;
-			update_val["upvotes"]=orig_upvoters;
+			update_val["upvotes"] = orig_upvoters;
 			return {true, "ok", "update", update_val};
-		}else if(vote_type=="down") {
-			if(target_announcement["upvoters"]) {
-				auto upvoters_arr=target_announcement["upvoters"].get_array();
-				for(auto i:upvoters_arr.value) {
-					if(user->user_oid==(std::string)i.get_string()) {
+		}
+		else if (vote_type == "down")
+		{
+			if (target_announcement["upvoters"])
+			{
+				auto upvoters_arr = target_announcement["upvoters"].get_array();
+				for (auto i : upvoters_arr.value)
+				{
+					if (user->user_oid == (std::string)i.get_string())
+					{
 						return {false, "你已经投过支持票了，不能投反对票。"};
 					}
 				}
 			}
-			size_t orig_downvoters=target_announcement["downvoters"]?std::distance(target_announcement["downvoters"].get_array().value.begin(),target_announcement["downvoters"].get_array().value.end()):0;
-			auto pull_result=fbdb["announcements"].update_one(document{}<<"_id"<<target_announcement["_id"].get_oid()<<finalize, document{}<<"$pull"<<open_document<<"downvoters"<<user->user_oid<<close_document<<finalize);
-			if(!pull_result->modified_count()) {
+			size_t orig_downvoters = target_announcement["downvoters"] ? std::distance(target_announcement["downvoters"].get_array().value.begin(), target_announcement["downvoters"].get_array().value.end()) : 0;
+			auto pull_result = fbdb["announcements"].update_one(document{} << "_id" << target_announcement["_id"].get_oid() << finalize, document{} << "$pull" << open_document << "downvoters" << user->user_oid << close_document << finalize);
+			if (!pull_result->modified_count())
+			{
 				orig_downvoters++;
-				fbdb["announcements"].update_one(document{}<<"_id"<<target_announcement["_id"].get_oid()<<finalize, document{}<<"$push"<<open_document<<"downvoters"<<user->user_oid<<close_document<<finalize);
-			}else{
+				fbdb["announcements"].update_one(document{} << "_id" << target_announcement["_id"].get_oid() << finalize, document{} << "$push" << open_document << "downvoters" << user->user_oid << close_document << finalize);
+			}
+			else
+			{
 				orig_downvoters--;
 			}
 			Json::Value update_val;
-			update_val["downvotes"]=orig_downvoters;
+			update_val["downvotes"] = orig_downvoters;
 			return {true, "ok", "update", update_val};
 		}
 		throw ServerErrorDemand{"Fell"};
 	}
-	
-	
-	LACTION0(FetchAnnouncementsAction, "fetch_announcements") {
-		Json::Value outvalues(Json::arrayValue);
-		auto client=mongodb_pool.acquire();
-		auto fbdb=(*client)["fastbuilder"];
-		auto cursor=fbdb["announcements"].find(document{}<<finalize, mongocxx::options::find{}.limit(10).sort(document{}<<"_id"<<-1<<finalize));
-		for(auto &i:cursor) {
-			Json::Value cur;
-			cur["title"]=(std::string)i["title"].get_string();
-			cur["content"]=(std::string)i["content"].get_string();
-			cur["date"]=(std::string)i["date"].get_string();
-			cur["author"]=(std::string)i["author"].get_string();
-			cur["uniqueId"]=(std::string)i["uniqueId"].get_string();
-			if(i["upvoters"]) {
-				cur["upvotes"]=std::distance(i["upvoters"].get_array().value.begin(),i["upvoters"].get_array().value.end());
-			}else{
-				cur["upvotes"]=0;
+
+	LACTION0(FetchAnnouncementsAction, "fetch_announcements")
+	{
+		if (!session->user->isDotCS)
+		{
+			Json::Value outvalues(Json::arrayValue);
+			auto client = mongodb_pool.acquire();
+			auto fbdb = (*client)["fastbuilder"];
+			auto cursor = fbdb["announcements"].find(document{} << finalize, mongocxx::options::find{}.limit(10).sort(document{} << "_id" << -1 << finalize));
+			for (auto &i : cursor)
+			{
+				Json::Value cur;
+				cur["title"] = (std::string)i["title"].get_string();
+				cur["content"] = (std::string)i["content"].get_string();
+				cur["date"] = (std::string)i["date"].get_string();
+				cur["author"] = (std::string)i["author"].get_string();
+				cur["uniqueId"] = (std::string)i["uniqueId"].get_string();
+				if (i["upvoters"])
+				{
+					cur["upvotes"] = std::distance(i["upvoters"].get_array().value.begin(), i["upvoters"].get_array().value.end());
+				}
+				else
+				{
+					cur["upvotes"] = 0;
+				}
+				if (i["downvoters"])
+				{
+					cur["downvotes"] = std::distance(i["downvoters"].get_array().value.begin(), i["downvoters"].get_array().value.end());
+				}
+				else
+				{
+					cur["downvotes"] = 0;
+				}
+				outvalues.append(cur);
 			}
-			if(i["downvoters"]) {
-				cur["downvotes"]=std::distance(i["downvoters"].get_array().value.begin(),i["downvoters"].get_array().value.end());
-			}else{
-				cur["downvotes"]=0;
-			}
-			outvalues.append(cur);
+			throw DirectReturnDemand{Utils::writeJSON(outvalues), "application/json"};
 		}
-		throw DirectReturnDemand{Utils::writeJSON(outvalues), "application/json"};
+		else
+		{
+			throw InvalidRequestDemand{"您没有权限使用本功能"};
+		}
 	}
-	
+
 	LACTION1(GetUserContactsAction, "get_user_contacts",
-			std::optional<int64_t>, identifier, "identifier") {
-		std::shared_ptr<FBWhitelist::User> user=session->user;
-		auto client=mongodb_pool.acquire();
-		auto fbdb=(*client)["fastbuilder"];
-		if(!identifier->has_value()) {
+			 std::optional<int64_t>, identifier, "identifier")
+	{
+		std::shared_ptr<FBWhitelist::User> user = session->user;
+		auto client = mongodb_pool.acquire();
+		auto fbdb = (*client)["fastbuilder"];
+		if (!identifier->has_value())
+		{
 			Json::Value ret(Json::ValueType::arrayValue);
-			auto the_document=document{};
-			if(!*(user->isAdministrator)) {
-				the_document<<"username"<<*user->username;
-			}else{
-				the_document<<"closed"<<false;
+			auto the_document = document{};
+			if (!*(user->isAdministrator))
+			{
+				the_document << "username" << *user->username;
 			}
-			auto user_contacts=fbdb["contacts"].find(the_document<<finalize);
-			for(auto &i:user_contacts) {
+			else
+			{
+				the_document << "closed" << false;
+			}
+			auto user_contacts = fbdb["contacts"].find(the_document << finalize);
+			for (auto &i : user_contacts)
+			{
 				Json::Value current_value;
-				current_value["title"]=(std::string)i["title"].get_string();
-				current_value["identifier"]=(int64_t)i["identifier"].get_int64();
-				if(i["closed"].get_bool()) {
-					current_value["closed"]=true;
-				}else{
-					current_value["has_update"]=*user->isAdministrator^i["user_can_add_msg"].get_bool();
+				current_value["title"] = (std::string)i["title"].get_string();
+				current_value["identifier"] = (int64_t)i["identifier"].get_int64();
+				if (i["closed"].get_bool())
+				{
+					current_value["closed"] = true;
+				}
+				else
+				{
+					current_value["has_update"] = *user->isAdministrator ^ i["user_can_add_msg"].get_bool();
 				}
 				ret.insert(0, current_value);
 			}
 			return {true, "ok", "contacts", ret};
 		}
-		auto search_doc=document{};
-		search_doc<<"identifier"<<**identifier;
-		if(!*user->isAdministrator) {
-			search_doc<<"username"<<*user->username;
+		auto search_doc = document{};
+		search_doc << "identifier" << **identifier;
+		if (!*user->isAdministrator)
+		{
+			search_doc << "username" << *user->username;
 		}
-		auto _spec_contact=fbdb["contacts"].find_one(search_doc<<finalize);
-		if(!_spec_contact.has_value()) {
+		auto _spec_contact = fbdb["contacts"].find_one(search_doc << finalize);
+		if (!_spec_contact.has_value())
+		{
 			return {false, "未找到对应联络"};
 		}
-		auto spec_contact=*_spec_contact;
+		auto spec_contact = *_spec_contact;
 		Json::Value ret_val;
-		ret_val["title"]=(std::string)spec_contact["title"].get_string();
+		ret_val["title"] = (std::string)spec_contact["title"].get_string();
 		Json::Value thread_arr(Json::ValueType::arrayValue);
-		bsoncxx::array::view thread_db_arr=(bsoncxx::array::view)spec_contact["thread"].get_array();
-		for(auto &i:thread_db_arr) {
+		bsoncxx::array::view thread_db_arr = (bsoncxx::array::view)spec_contact["thread"].get_array();
+		for (auto &i : thread_db_arr)
+		{
 			Json::Value sub_val;
-			sub_val["sender"]=(std::string)i["sender"].get_string();
-			sub_val["content"]=(std::string)i["content"].get_string();
-			sub_val["time"]=(int64_t)i["time"].get_int64();
+			sub_val["sender"] = (std::string)i["sender"].get_string();
+			sub_val["content"] = (std::string)i["content"].get_string();
+			sub_val["time"] = (int64_t)i["time"].get_int64();
 			thread_arr.insert(0, sub_val);
 		}
-		ret_val["thread"]=thread_arr;
-		ret_val["user_can_add_msg"]=*user->isAdministrator|spec_contact["user_can_add_msg"].get_bool();
-		if(spec_contact["closed"].get_bool()) {
-			ret_val["user_can_add_msg"]=false;
+		ret_val["thread"] = thread_arr;
+		ret_val["user_can_add_msg"] = *user->isAdministrator | spec_contact["user_can_add_msg"].get_bool();
+		if (spec_contact["closed"].get_bool())
+		{
+			ret_val["user_can_add_msg"] = false;
 		}
-		ret_val["identifier"]=(int64_t)spec_contact["identifier"].get_int64();
+		ret_val["identifier"] = (int64_t)spec_contact["identifier"].get_int64();
 		return {true, "found", "item", ret_val};
 	}
-	
+
 	LACTION2(CreateUserContactAction, "create_user_contact",
-			std::string, title, "title",
-			std::string, content, "content") {
-		auto client=mongodb_pool.acquire();
-		auto fbdb=(*client)["fastbuilder"];
-		auto old_contact=fbdb["contacts"].find_one(document{}<<"username"<<session->user->username<<"closed"<<false<<finalize);
-		if(old_contact.has_value()) {
-			return {false, "已有过去联络存在，请耐心等待，或删除对应联络。"};
-		}
-		if(content->length()>1000) {
-			return {false, "联络内容太长"};
-		}else if(title->length()>32) {
-			return {false, "标题太长"};
-		}
-		int64_t con_id=(int64_t)time(nullptr);
-		fbdb["contacts"].insert_one(document{}<<"username"<<*session->user->username<<"title"<<*title<<"thread"<<open_array<<open_document<<"sender"<<*session->user->username<<"content"<<*content<<"time"<<(int64_t)time(nullptr)<<close_document<<close_array<<"closed"<<false<<"user_can_add_msg"<<false<<"identifier"<<con_id<<finalize);
-		std::string tg_notification=fmt::format("*New Contact*\nCONTACTID: {}\nUser: `{}`\nTitle: `{}`\n\n```\n{}\n```", con_id, *session->user->username, *title, *content);
-		std::thread([tg_notification]() {
+			 std::string, title, "title",
+			 std::string, content, "content")
+	{
+		if (!session->user->isDotCS)
+		{
+			auto client = mongodb_pool.acquire();
+			auto fbdb = (*client)["fastbuilder"];
+			auto old_contact = fbdb["contacts"].find_one(document{} << "username" << session->user->username << "closed" << false << finalize);
+			if (old_contact.has_value())
+			{
+				return {false, "已有过去联络存在，请耐心等待，或删除对应联络。"};
+			}
+			if (content->length() > 1000)
+			{
+				return {false, "联络内容太长"};
+			}
+			else if (title->length() > 32)
+			{
+				return {false, "标题太长"};
+			}
+			int64_t con_id = (int64_t)time(nullptr);
+			fbdb["contacts"].insert_one(document{} << "username" << *session->user->username << "title" << *title << "thread" << open_array << open_document << "sender" << *session->user->username << "content" << *content << "time" << (int64_t)time(nullptr) << close_document << close_array << "closed" << false << "user_can_add_msg" << false << "identifier" << con_id << finalize);
+			std::string tg_notification = fmt::format("*New Contact*\nCONTACTID: {}\nUser: `{}`\nTitle: `{}`\n\n```\n{}\n```", con_id, *session->user->username, *title, *content);
+			std::thread([tg_notification]()
+						{
 			httplib::Client tgClient("https://api.telegram.org");
 			Json::Value postContent;
 			postContent["chat_id"]=Secrets::get_telegram_chat_id();
 			postContent["parse_mode"]="MarkdownV2";
 			postContent["text"]=tg_notification;
-			tgClient.Post(fmt::format("/{}/sendMessage", Secrets::get_telegram_bot_token()), Utils::writeJSON(postContent), "application/json");
-		}).detach();
-		return {true, "OK", "identifier", con_id};
+			tgClient.Post(fmt::format("/{}/sendMessage", Secrets::get_telegram_bot_token()), Utils::writeJSON(postContent), "application/json"); })
+				.detach();
+			return {true, "OK", "identifier", con_id};
+		}
+		else
+		{
+			return {false, "你没有权限使用本功能"};
+		}
 	}
-	
+
 	LACTION4(UpdateUserContactAction, "update_user_contact",
-			int64_t, identifier, "identifier",
-			std::string, content, "content",
-			std::optional<bool>, anonymous, "anonymous",
-			std::optional<bool>, closing, "closing") {
-		auto client=mongodb_pool.acquire();
-		auto fbdb=(*client)["fastbuilder"];
-		auto contact_item=fbdb["contacts"].find_one(document{}<<"identifier"<<*identifier<<finalize);
-		if(!contact_item.has_value()) {
-			return {false, "不存在此联络"};
-		}
-		auto r_contact_item=*contact_item;
-		if(r_contact_item["closed"].get_bool()) {
-			return {false, "联络已经被关闭"};
-		}
-		std::string name="用户中心管理员";
-		if(!session->user->isAdministrator) {
-			if(((std::string)r_contact_item["username"].get_string())!=session->user->username) {
+			 int64_t, identifier, "identifier",
+			 std::string, content, "content",
+			 std::optional<bool>, anonymous, "anonymous",
+			 std::optional<bool>, closing, "closing")
+	{
+		if (!session->user->isDotCS)
+		{
+			auto client = mongodb_pool.acquire();
+			auto fbdb = (*client)["fastbuilder"];
+			auto contact_item = fbdb["contacts"].find_one(document{} << "identifier" << *identifier << finalize);
+			if (!contact_item.has_value())
+			{
 				return {false, "不存在此联络"};
 			}
-			if(!r_contact_item["user_can_add_msg"].get_bool()) {
-				return {false, "请等待回复"};
+			auto r_contact_item = *contact_item;
+			if (r_contact_item["closed"].get_bool())
+			{
+				return {false, "联络已经被关闭"};
 			}
-			fbdb["contacts"].update_one(document{}<<"identifier"<<*identifier<<finalize, document{}<<"$push"<<open_document<<"thread"<<open_document<<"content"<<*content<<"sender"<<*session->user->username<<"time"<<(int64_t)time(nullptr)<<close_document<<close_document<<"$set"<<open_document<<"user_can_add_msg"<<false<<close_document<<finalize);
-			goto tg_notify;
-			return {true, "OK"};
-		}
-		if(!anonymous->has_value()||!**anonymous) {
-			name=session->user->username;
-		}
-		fbdb["contacts"].update_one(document{}<<"identifier"<<*identifier<<finalize, document{}<<"$push"<<open_document<<"thread"<<open_document<<"content"<<*content<<"sender"<<name<<"time"<<(int64_t)time(nullptr)<<close_document<<close_document<<"$set"<<open_document<<"user_can_add_msg"<<true<<close_document<<finalize);
-		if(closing->has_value()&&**closing) {
-			fbdb["contacts"].update_one(document{}<<"identifier"<<*identifier<<finalize, document{}<<"$set"<<open_document<<"closed"<<true<<close_document<<finalize);
-		}
-		{
+			std::string name = "用户中心管理员";
+			if (!session->user->isAdministrator)
+			{
+				if (((std::string)r_contact_item["username"].get_string()) != session->user->username)
+				{
+					return {false, "不存在此联络"};
+				}
+				if (!r_contact_item["user_can_add_msg"].get_bool())
+				{
+					return {false, "请等待回复"};
+				}
+				fbdb["contacts"].update_one(document{} << "identifier" << *identifier << finalize, document{} << "$push" << open_document << "thread" << open_document << "content" << *content << "sender" << *session->user->username << "time" << (int64_t)time(nullptr) << close_document << close_document << "$set" << open_document << "user_can_add_msg" << false << close_document << finalize);
+				goto tg_notify;
+				return {true, "OK"};
+			}
+			if (!anonymous->has_value() || !**anonymous)
+			{
+				name = session->user->username;
+			}
+			fbdb["contacts"].update_one(document{} << "identifier" << *identifier << finalize, document{} << "$push" << open_document << "thread" << open_document << "content" << *content << "sender" << name << "time" << (int64_t)time(nullptr) << close_document << close_document << "$set" << open_document << "user_can_add_msg" << true << close_document << finalize);
+			if (closing->has_value() && **closing)
+			{
+				fbdb["contacts"].update_one(document{} << "identifier" << *identifier << finalize, document{} << "$set" << open_document << "closed" << true << close_document << finalize);
+			}
+			{
 			tg_notify:
-			std::string tg_notification=fmt::format("*Update on Contact*\nCONTACTID: {}\nOperator: `{}`\n", *identifier, *session->user->username);
-			if(*anonymous&&**anonymous) {
-				tg_notification+="*ANONYMOUS MODE*\n";
-			}
-			if(*closing&&**closing) {
-				tg_notification+="*CLOSING*\n";
-			}
-			tg_notification+="\n\n*Target Contact Thread*\n";
-			// Get updated value
-			auto spec_contact=*(fbdb["contacts"].find_one(document{}<<"identifier"<<*identifier<<finalize));
-			tg_notification+=fmt::format("*Title*: `{}`\n", (std::string)spec_contact["title"].get_string());
-			int no=1;
-			bsoncxx::array::view thread_db_arr=(bsoncxx::array::view)spec_contact["thread"].get_array();
-			for(auto &i:thread_db_arr) {
-				tg_notification+=fmt::format("*\\#{}, {}*:\n```\n{}\n```\n", no, i["sender"].get_string(), i["content"].get_string());
-				no++;
-			}
-			std::thread([tg_notification]() {
+				std::string tg_notification = fmt::format("*Update on Contact*\nCONTACTID: {}\nOperator: `{}`\n", *identifier, *session->user->username);
+				if (*anonymous && **anonymous)
+				{
+					tg_notification += "*ANONYMOUS MODE*\n";
+				}
+				if (*closing && **closing)
+				{
+					tg_notification += "*CLOSING*\n";
+				}
+				tg_notification += "\n\n*Target Contact Thread*\n";
+				// Get updated value
+				auto spec_contact = *(fbdb["contacts"].find_one(document{} << "identifier" << *identifier << finalize));
+				tg_notification += fmt::format("*Title*: `{}`\n", (std::string)spec_contact["title"].get_string());
+				int no = 1;
+				bsoncxx::array::view thread_db_arr = (bsoncxx::array::view)spec_contact["thread"].get_array();
+				for (auto &i : thread_db_arr)
+				{
+					tg_notification += fmt::format("*\\#{}, {}*:\n```\n{}\n```\n", no, i["sender"].get_string(), i["content"].get_string());
+					no++;
+				}
+				std::thread([tg_notification]()
+							{
 				httplib::Client tgClient("https://api.telegram.org");
 				Json::Value postContent;
 				postContent["chat_id"]=Secrets::get_telegram_chat_id();
 				postContent["parse_mode"]="MarkdownV2";
 				postContent["text"]=tg_notification;
-				tgClient.Post(fmt::format("/{}/sendMessage", Secrets::get_telegram_bot_token()), Utils::writeJSON(postContent), "application/json");
-			}).detach();
+				tgClient.Post(fmt::format("/{}/sendMessage", Secrets::get_telegram_bot_token()), Utils::writeJSON(postContent), "application/json"); })
+					.detach();
+			}
+			return {true, "OK"};
 		}
-		return {true, "OK"};
+		else
+		{
+			return {false, "你没有权限使用本功能"};
+		}
 	}
-	
+
 	LACTION1(DeleteUserContactAction, "delete_user_contact",
-			int64_t, identifier, "identifier") {
-		auto client=mongodb_pool.acquire();
-		auto fbdb=(*client)["fastbuilder"];
-		if(*session->user->isAdministrator) {
-			fbdb["contacts"].delete_one(document{}<<"identifier"<<*identifier<<finalize);
+			 int64_t, identifier, "identifier")
+	{
+		if (!session->user->isDotCS)
+		{
+			auto client = mongodb_pool.acquire();
+			auto fbdb = (*client)["fastbuilder"];
+			if (*session->user->isAdministrator)
+			{
+				fbdb["contacts"].delete_one(document{} << "identifier" << *identifier << finalize);
+				return {true};
+			}
+			fbdb["contacts"].delete_one(document{} << "username" << *session->user->username << "identifier" << *identifier << finalize);
 			return {true};
 		}
-		fbdb["contacts"].delete_one(document{}<<"username"<<*session->user->username<<"identifier"<<*identifier<<finalize);
-		return {true};
+		else
+		{
+			return {false, "你没有权限使用本功能"};
+		}
 	}
-	
+
 	LACTION7(GetWhitelistAction, "get_whitelist",
-			std::optional<std::string>, username, "username",
-			std::optional<std::string>, _wquery, "whitelist_query",
-			std::optional<uint32_t>, _wpage, "whitelist_page",
-			std::optional<std::string>, pquery_username, "p_username",
-			std::optional<std::string>, pquery_helper, "p_hname",
-			std::optional<std::string>, pquery_description, "p_desc",
-			std::optional<uint32_t>, _ppage, "payment_log_page") {
-		if(username->has_value()) {
-			auto client=mongodb_pool.acquire();
-			auto user=(*client)["fastbuilder"]["whitelist"].find_one(document{}<<"username"<<**username<<finalize);
-			std::string user_json_str=bsoncxx::to_json(*user);
-			if(!user.has_value()) {
+			 std::optional<std::string>, username, "username",
+			 std::optional<std::string>, _wquery, "whitelist_query",
+			 std::optional<uint32_t>, _wpage, "whitelist_page",
+			 std::optional<std::string>, pquery_username, "p_username",
+			 std::optional<std::string>, pquery_helper, "p_hname",
+			 std::optional<std::string>, pquery_description, "p_desc",
+			 std::optional<uint32_t>, _ppage, "payment_log_page")
+	{
+		if (username->has_value())
+		{
+			auto client = mongodb_pool.acquire();
+			auto user = (*client)["fastbuilder"]["whitelist"].find_one(document{} << "username" << **username << finalize);
+			std::string user_json_str = bsoncxx::to_json(*user);
+			if (!user.has_value())
+			{
 				throw DirectReturnDemand{"{}", "application/json"};
 			}
 			throw DirectReturnDemand{user_json_str, "application/json"};
 		}
-		if((*_wquery)->size()<4) {
+		if ((*_wquery)->size() < 4)
+		{
 			throw InvalidRequestDemand{"Invalid item `wquery`."};
 		}
-		std::string const& wquery=**_wquery;
-		auto query=document{};
-		if(wquery[0]=='1') {
-			query<<"admin"<<true;
+		std::string const &wquery = **_wquery;
+		auto query = document{};
+		if (wquery[0] == '1')
+		{
+			query << "admin" << true;
 		}
-		if(wquery[1]=='1') {
-			query<<"allowed_to_use_phoenix"<<true;
+		if (wquery[1] == '1')
+		{
+			query << "allowed_to_use_phoenix" << true;
 		}
-		if(wquery[2]=='1') {
-			query<<"banned"<<true;
+		if (wquery[2] == '1')
+		{
+			query << "banned" << true;
 		}
-		if(wquery[3]=='1') {
-			query<<"promocodeCount"<<open_document<<"$ne"<<(int32_t)0<<"$exists"<<true<<close_document;
+		if (wquery[3] == '1')
+		{
+			query << "promocodeCount" << open_document << "$ne" << (int32_t)0 << "$exists" << true << close_document;
 		}
-		if(wquery.size()>4) {
-			query<<"username"<<open_document<<"$regex"<<bsoncxx::types::b_regex{wquery.substr(4)}<<close_document;
+		if (wquery.size() > 4)
+		{
+			query << "username" << open_document << "$regex" << bsoncxx::types::b_regex{wquery.substr(4)} << close_document;
 		}
-		unsigned int wpage=_wpage->has_value()?**_wpage-1:0;
-		auto client=mongodb_pool.acquire();
-		auto fbdb=(*client)["fastbuilder"];
-		mongocxx::options::find wlist_fo=mongocxx::options::find{}.skip(20*wpage).limit(20);
-		auto wlist_o=fbdb["whitelist"].find(query<<finalize, wlist_fo);
+		unsigned int wpage = _wpage->has_value() ? **_wpage - 1 : 0;
+		auto client = mongodb_pool.acquire();
+		auto fbdb = (*client)["fastbuilder"];
+		mongocxx::options::find wlist_fo = mongocxx::options::find{}.skip(20 * wpage).limit(20);
+		auto wlist_o = fbdb["whitelist"].find(query << finalize, wlist_fo);
 		Json::Value wlist_jv(Json::ValueType::arrayValue);
-		for(auto &i:wlist_o) {
-			std::string i_str=bsoncxx::to_json(i);
+		for (auto &i : wlist_o)
+		{
+			std::string i_str = bsoncxx::to_json(i);
 			Json::Value item_jv;
 			Utils::parseJSON(i_str, &item_jv);
 			wlist_jv.append(item_jv);
 		}
-		auto plistquery=document{};
-		if(pquery_username->has_value()) {
-			plistquery<<"username"<<open_document<<"$regex"<<bsoncxx::types::b_regex{**pquery_username}<<close_document;
+		auto plistquery = document{};
+		if (pquery_username->has_value())
+		{
+			plistquery << "username" << open_document << "$regex" << bsoncxx::types::b_regex{**pquery_username} << close_document;
 		}
-		if(pquery_helper->has_value()) {
-			plistquery<<"helper"<<open_document<<"$regex"<<bsoncxx::types::b_regex{**pquery_helper}<<close_document;
+		if (pquery_helper->has_value())
+		{
+			plistquery << "helper" << open_document << "$regex" << bsoncxx::types::b_regex{**pquery_helper} << close_document;
 		}
-		if(pquery_description->has_value()) {
-			plistquery<<"description"<<open_document<<"$regex"<<bsoncxx::types::b_regex{**pquery_description}<<close_document;
+		if (pquery_description->has_value())
+		{
+			plistquery << "description" << open_document << "$regex" << bsoncxx::types::b_regex{**pquery_description} << close_document;
 		}
-		unsigned int ppage=_ppage->has_value()?**_ppage-1:0;
-		auto plist_fo=mongocxx::options::find{}.sort(document{}<<"_id"<<-1<<finalize).skip(20*ppage).limit(20);
-		auto payments_o=fbdb["payments"].find(plistquery<<finalize, plist_fo);
+		unsigned int ppage = _ppage->has_value() ? **_ppage - 1 : 0;
+		auto plist_fo = mongocxx::options::find{}.sort(document{} << "_id" << -1 << finalize).skip(20 * ppage).limit(20);
+		auto payments_o = fbdb["payments"].find(plistquery << finalize, plist_fo);
 		Json::Value plist_jv(Json::ValueType::arrayValue);
-		for(auto &i:payments_o) {
-			std::string i_str=bsoncxx::to_json(i);
+		for (auto &i : payments_o)
+		{
+			std::string i_str = bsoncxx::to_json(i);
 			Json::Value item_jv;
 			Utils::parseJSON(i_str, &item_jv);
-			uint64_t date_v=item_jv["date"]["$date"].asUInt64();
-			item_jv["date"]=date_v;
+			uint64_t date_v = item_jv["date"]["$date"].asUInt64();
+			item_jv["date"] = date_v;
 			plist_jv.append(item_jv);
 		}
-		unsigned int pn_wlist=(unsigned int)(fbdb["whitelist"].estimated_document_count()/20.0);
-		if(fbdb["whitelist"].estimated_document_count()/20.0>pn_wlist)pn_wlist++;
-		unsigned int pn_plist=(unsigned int)(fbdb["payments"].estimated_document_count()/20.0);
-		if(fbdb["payments"].estimated_document_count()/20.0>pn_plist)pn_plist++;
+		unsigned int pn_wlist = (unsigned int)(fbdb["whitelist"].estimated_document_count() / 20.0);
+		if (fbdb["whitelist"].estimated_document_count() / 20.0 > pn_wlist)
+			pn_wlist++;
+		unsigned int pn_plist = (unsigned int)(fbdb["payments"].estimated_document_count() / 20.0);
+		if (fbdb["payments"].estimated_document_count() / 20.0 > pn_plist)
+			pn_plist++;
 		return {true, "ok", "wlist", wlist_jv, "payments", plist_jv, "pn_wlist", pn_wlist, "pn_plist", pn_plist};
 	}
-	
-	LACTION2(PublishAnnouncementAction, "publish_announcement",
-			std::string, title, "title",
-			std::string, content, "content") {
-		time_t m_time=time(nullptr);
-		struct tm *ptr_time=gmtime(&m_time);
-		time_t utc_time=mktime(ptr_time);
-		time_t cn_time=utc_time+3600*8;
-		std::string cn_time_str(ctime(&cn_time));
-		auto client=mongodb_pool.acquire();
-		auto fbdb=(*client)["fastbuilder"];
-		fbdb["announcements"].insert_one(document{}<<"title"<<*title<<"content"<<*content<<"date"<<cn_time_str<<"author"<<*session->user->username<<"uniqueId"<<Utils::generateUUID()<<finalize);
-		return {true};
-	}
-	
-	LACTION1(RemoveAnnouncementAction, "remove_announcement",
-			std::string, uniqueId, "param") {
-		auto client=mongodb_pool.acquire();
-		auto fbdb=(*client)["fastbuilder"];
-		fbdb["announcements"].delete_one(document{}<<"uniqueId"<<*uniqueId<<finalize);
-		return {true};
-	}
-	
-	static FBUCActionCluster dbRelatedGeneralActions(0, {
-		Action::enmap(new FetchAnnouncementsAction),
-		Action::enmap(new VoteAnnouncementAction),
-		Action::enmap(new GetUserContactsAction),
-		Action::enmap(new CreateUserContactAction),
-		Action::enmap(new UpdateUserContactAction),
-		Action::enmap(new DeleteUserContactAction)
-	});
-	
-	static FBUCActionCluster dbRelatedAdministrativeActions(1, {
-		Action::enmap(new GetWhitelistAction),
-		Action::enmap(new PublishAnnouncementAction),
-		Action::enmap(new RemoveAnnouncementAction)
-	});
-};
 
+	LACTION2(PublishAnnouncementAction, "publish_announcement",
+			 std::string, title, "title",
+			 std::string, content, "content")
+	{
+		time_t m_time = time(nullptr);
+		struct tm *ptr_time = gmtime(&m_time);
+		time_t utc_time = mktime(ptr_time);
+		time_t cn_time = utc_time + 3600 * 8;
+		std::string cn_time_str(ctime(&cn_time));
+		auto client = mongodb_pool.acquire();
+		auto fbdb = (*client)["fastbuilder"];
+		fbdb["announcements"].insert_one(document{} << "title" << *title << "content" << *content << "date" << cn_time_str << "author" << *session->user->username << "uniqueId" << Utils::generateUUID() << finalize);
+		return {true};
+	}
+
+	LACTION1(RemoveAnnouncementAction, "remove_announcement",
+			 std::string, uniqueId, "param")
+	{
+		auto client = mongodb_pool.acquire();
+		auto fbdb = (*client)["fastbuilder"];
+		fbdb["announcements"].delete_one(document{} << "uniqueId" << *uniqueId << finalize);
+		return {true};
+	}
+
+	static FBUCActionCluster dbRelatedGeneralActions(0, {Action::enmap(new FetchAnnouncementsAction),
+														 Action::enmap(new VoteAnnouncementAction),
+														 Action::enmap(new GetUserContactsAction),
+														 Action::enmap(new CreateUserContactAction),
+														 Action::enmap(new UpdateUserContactAction),
+														 Action::enmap(new DeleteUserContactAction)});
+
+	static FBUCActionCluster dbRelatedAdministrativeActions(1, {Action::enmap(new GetWhitelistAction),
+																Action::enmap(new PublishAnnouncementAction),
+																Action::enmap(new RemoveAnnouncementAction)});
+};

--- a/modules/user_center/actions/marketplace.cpp
+++ b/modules/user_center/actions/marketplace.cpp
@@ -7,276 +7,366 @@
 
 extern httplib::Client stripeClient;
 
-namespace FBUC {
-	LACTION0(GetProductListAction, "get_product_list") {
-		FBWhitelist::User &user=*session->user;
-		std::vector<Product *> const& products=all_products();
+namespace FBUC
+{
+	LACTION0(GetProductListAction, "get_product_list")
+	{
+		FBWhitelist::User &user = *session->user;
+		std::vector<Product *> const &products = all_products();
 		Json::Value product_list(Json::arrayValue);
-		for(Product *i:products) {
-			if(i->forbid_cart()||!i->check_on(user))
+		for (Product *i : products)
+		{
+			if (i->forbid_cart() || !i->check_on(user))
 				continue;
 			product_list.append(i->toJSON());
 		}
-		return {true,"","products",product_list};
+		return {true, "", "products", product_list};
 	}
-	
+
 	LACTION1(AddProductToCartAction, "add_product_to_cart",
-			std::string, _product_id, "product_id") {
-		unsigned int product_id=std::stoi(_product_id);
-		Product *target=nullptr;
-		std::vector<Product *> const& products=all_products();
-		for(Product *i:products) {
-			if(i->product_id()==product_id) {
-				target=i;
+			 std::string, _product_id, "product_id")
+	{
+
+		unsigned int product_id = std::stoi(_product_id);
+		Product *target = nullptr;
+		std::vector<Product *> const &products = all_products();
+		for (Product *i : products)
+		{
+			if (i->product_id() == product_id)
+			{
+				target = i;
 				break;
 			}
 		}
-		if(!target) {
+		if (!target)
+		{
 			return {false, "未找到商品"};
 		}
-		if(!target->check_on(*session->user)) {
+		if (!target->check_on(*session->user))
+		{
 			return {false, "你未满足购买此商品的所需条件"};
 		}
-		if(target->forbid_cart()) {
+		if (target->forbid_cart())
+		{
 			return {false, "商品禁止加入购物车。"};
 		}
-		if(target->no_multi_add()) {
-			for(Product *i:session->cart) {
-				if(i==target) {
+		if (target->no_multi_add())
+		{
+			for (Product *i : session->cart)
+			{
+				if (i == target)
+				{
 					return {false, "商品已在购物车"};
 				}
 			}
 		}
-		if(session->cart.size()>8) {
+		if (session->cart.size() > 8)
+		{
 			return {false, "购物车内商品过多"};
 		}
 		session->cart.push_back(target);
 		return {true, ""};
 	}
-	
-	LACTION0(GetShoppingCartAction, "get_shopping_cart") {
+
+	LACTION0(GetShoppingCartAction, "get_shopping_cart")
+	{
 		Json::Value ret_val(Json::arrayValue);
-		for(Product *i:session->cart) {
+		for (Product *i : session->cart)
+		{
 			ret_val.append(i->toJSON());
 		}
 		throw DirectReturnDemand{Utils::writeJSON(ret_val), "application/json"};
 	}
-	
+
 	LACTION1(EraseFromShoppingCartAction, "erase_from_shopping_cart",
-			std::string, _product_id, "product_id") {
-		uint32_t product_id=std::stoi(_product_id);
-		for(std::vector<Product *>::iterator it=session->cart.begin(); it!=session->cart.end();) {
-			if((*it)->product_id()==product_id) {
-				it=session->cart.erase(it);
+			 std::string, _product_id, "product_id")
+	{
+		uint32_t product_id = std::stoi(_product_id);
+		for (std::vector<Product *>::iterator it = session->cart.begin(); it != session->cart.end();)
+		{
+			if ((*it)->product_id() == product_id)
+			{
+				it = session->cart.erase(it);
 				// Erase only one
 				break;
-			}else{
+			}
+			else
+			{
 				it++;
 			}
 		}
 		return {true, ""};
 	}
-	
-	LACTION0(GenerateBillAction, "generate_bill") {
-		if(!session->cart.size()) {
-			return {false, "购物车里没有商品"};
-		}
-		FBUC::PaymentIntent *currentPaymentIntent=new FBUC::PaymentIntent;
-		currentPaymentIntent->session=session;
-		if(session->user->banned_from_payment) {
-			currentPaymentIntent->banned_from_payment=true;
-		}else{
-			currentPaymentIntent->needs_verify=false;
-			//currentPaymentIntent->needs_verify=!session->user->payment_verify_fingerprint.has_value();
-		}
-		for(Product *i:session->cart) {
-			currentPaymentIntent->content.push_back(i);
-			if(i->card_only()) {
-				currentPaymentIntent->card_only=true;
+
+	LACTION0(GenerateBillAction, "generate_bill")
+	{
+		if (!session->user->isDotCS)
+		{
+			if (!session->cart.size())
+			{
+				return {false, "购物车里没有商品"};
 			}
-			currentPaymentIntent->price+=i->price();
-			if((unsigned int)i->price()*0.8==0&&i->price()!=0) {
-				currentPaymentIntent->helper_price+=1;
-			}else{
-				currentPaymentIntent->helper_price+=i->price()*0.8;
+			FBUC::PaymentIntent *currentPaymentIntent = new FBUC::PaymentIntent;
+			currentPaymentIntent->session = session;
+			if (session->user->banned_from_payment)
+			{
+				currentPaymentIntent->banned_from_payment = true;
 			}
+			else
+			{
+				currentPaymentIntent->needs_verify = false;
+				// currentPaymentIntent->needs_verify=!session->user->payment_verify_fingerprint.has_value();
+			}
+			for (Product *i : session->cart)
+			{
+				currentPaymentIntent->content.push_back(i);
+				if (i->card_only())
+				{
+					currentPaymentIntent->card_only = true;
+				}
+				currentPaymentIntent->price += i->price();
+				if ((unsigned int)i->price() * 0.8 == 0 && i->price() != 0)
+				{
+					currentPaymentIntent->helper_price += 1;
+				}
+				else
+				{
+					currentPaymentIntent->helper_price += i->price() * 0.8;
+				}
+			}
+			currentPaymentIntent->points_delta = currentPaymentIntent->price * 7;
+			if (currentPaymentIntent->price < 6)
+			{
+				currentPaymentIntent->stripe_price = 6;
+			}
+			else
+			{
+				currentPaymentIntent->stripe_price = currentPaymentIntent->price;
+			}
+			auto ptr = std::shared_ptr<FBUC::PaymentIntent>(currentPaymentIntent);
+			payments_mutex.lock();
+			payment_intents[session->user->username] = ptr;
+			payments_mutex.unlock();
+			session->payment_intent = ptr;
+			return {true, "", "location", "/pay"};
 		}
-		currentPaymentIntent->points_delta=currentPaymentIntent->price*7;
-		if(currentPaymentIntent->price<6) {
-			currentPaymentIntent->stripe_price=6;
-		}else{
-			currentPaymentIntent->stripe_price=currentPaymentIntent->price;
+		else
+		{
+			return {false, "请前往 幻梦互联用户中心下单。您没有权限在FastBuilder用户中心下单。"};
 		}
-		auto ptr=std::shared_ptr<FBUC::PaymentIntent>(currentPaymentIntent);
-		payments_mutex.lock();
-		payment_intents[session->user->username]=ptr;
-		payments_mutex.unlock();
-		session->payment_intent=ptr;
-		return {true, "", "location", "/pay"};
 	}
-	
+
 	LACTION1(GetBillAction, "get_bill",
-			Session, session, "secret") {
-		if(!session->payment_intent) {
+			 Session, session, "secret")
+	{
+		if (!session->payment_intent)
+		{
 			return {false, "", "show", "未找到交易或交易已完成"};
 		}
-		std::shared_ptr<FBUC::PaymentIntent> intent=session->payment_intent;
+		std::shared_ptr<FBUC::PaymentIntent> intent = session->payment_intent;
 		std::string show;
-		for(Product *sub:intent->content) {
-			if(sub->card_only()) {
-				show+="[仅官方支付] ";
+		for (Product *sub : intent->content)
+		{
+			if (sub->card_only())
+			{
+				show += "[仅官方支付] ";
 			}
-			show+=fmt::format("{}: ￥{}\n", sub->product_name(), sub->price());
+			show += fmt::format("{}: ￥{}\n", sub->product_name(), sub->price());
 		}
-		show+=fmt::format("\n<b>合计</b>: ￥{}\n",intent->price?std::to_string(intent->price):"免费");
-		if(intent->stripe_price!=intent->price&&intent->price!=0) {
-			show+=fmt::format("官方支付最低价: ￥{}\n", intent->stripe_price);
+		show += fmt::format("\n<b>合计</b>: ￥{}\n", intent->price ? std::to_string(intent->price) : "免费");
+		if (intent->stripe_price != intent->price && intent->price != 0)
+		{
+			show += fmt::format("官方支付最低价: ￥{}\n", intent->stripe_price);
 		}
-		if(intent->card_only) {
-			show+="注意：含有仅官方支付商品。\n";
+		if (intent->card_only)
+		{
+			show += "注意：含有仅官方支付商品。\n";
 		}
-		show+=fmt::format("现有 Points: <b style=\"color:orange;\">{}</b>\n", *session->user->points);
-		if(intent->points_delta>=0) {
-			show+=fmt::format("获得 Points: <b style=\"color:blue;\">{}</b>\n", intent->points_delta);
-		}else{
-			show+=fmt::format("消耗 Points: <b style=\"color:red;\">{}</b>\n", -intent->points_delta);
+		show += fmt::format("现有 Points: <b style=\"color:orange;\">{}</b>\n", *session->user->points);
+		if (intent->points_delta >= 0)
+		{
+			show += fmt::format("获得 Points: <b style=\"color:blue;\">{}</b>\n", intent->points_delta);
 		}
-		if(intent->banned_from_payment) {
-			show+="<hr/><b style=\"color:red;\">由于您的支付信息与他人出现重合，此账户已被永久禁止支付，其他功能不受影响。</b>";
+		else
+		{
+			show += fmt::format("消耗 Points: <b style=\"color:red;\">{}</b>\n", -intent->points_delta);
 		}
-		if(intent->needs_verify) {
-			show+="<hr/><b style=\"color:blue;\">由于我们需要验证您的账户唯一性，本次支付只能使用本页面上的支付方式完成。</b>\n";
+		if (intent->banned_from_payment)
+		{
+			show += "<hr/><b style=\"color:red;\">由于您的支付信息与他人出现重合，此账户已被永久禁止支付，其他功能不受影响。</b>";
 		}
-		bool can_use_point=true;
-		if(intent->points_delta<0||intent->banned_from_payment||(session->user->free&&!session->user->expiration_date.stillAlive())) {
-			can_use_point=false;
+		if (intent->needs_verify)
+		{
+			show += "<hr/><b style=\"color:blue;\">由于我们需要验证您的账户唯一性，本次支付只能使用本页面上的支付方式完成。</b>\n";
 		}
-		if(getenv("DEBUG")) {
-			show+="\n\n<b style=\"color:red;\">调试模式</b>";
-			return {true,"", "show", show, "codepwn_pay_available", false, "isfree", intent->helper_price==0&&intent->price==0, "can_use_point", can_use_point, "needs_verify", intent->needs_verify};
+		bool can_use_point = true;
+		if (intent->points_delta < 0 || intent->banned_from_payment || (session->user->free && !session->user->expiration_date.stillAlive()))
+		{
+			can_use_point = false;
 		}
-		return {true, "", "show", show, "codepwn_pay_available", false, "isfree", intent->helper_price==0&&intent->price==0, "can_use_point", can_use_point, "needs_verify", intent->needs_verify};
+		if (getenv("DEBUG"))
+		{
+			show += "\n\n<b style=\"color:red;\">调试模式</b>";
+			return {true, "", "show", show, "codepwn_pay_available", false, "isfree", intent->helper_price == 0 && intent->price == 0, "can_use_point", can_use_point, "needs_verify", intent->needs_verify};
+		}
+		return {true, "", "show", show, "codepwn_pay_available", false, "isfree", intent->helper_price == 0 && intent->price == 0, "can_use_point", can_use_point, "needs_verify", intent->needs_verify};
 	}
-	
-	LACTION0(CheckPaymentAction, "check_payment") {
-		std::shared_ptr<FBUC::PaymentIntent> intent=session->payment_intent;
-		if(!intent) {
+
+	LACTION0(CheckPaymentAction, "check_payment")
+	{
+		std::shared_ptr<FBUC::PaymentIntent> intent = session->payment_intent;
+		if (!intent)
+		{
 			return {false, "会话已经过期", "expired", true};
 		}
-		if(!intent->paired||!intent->approved) {
+		if (!intent->paired || !intent->approved)
+		{
 			return {false, "尚未确认", "paired", intent->paired, "price", intent->price};
 		}
 		return {true, "Well done", "paired", true, "approved", true};
 	}
-	
-	LACTION0(UCGetBalanceAction, "get_balance") {
+
+	LACTION0(UCGetBalanceAction, "get_balance")
+	{
 		Json::Value ret;
-		if(session->user->promocode_count.has_value()) {
+		if (session->user->promocode_count.has_value())
+		{
 			ret.append(*session->user->promocode_count);
-		}else{
+		}
+		else
+		{
 			ret.append(0);
 		}
 		ret.append(0);
 		ret.append(0);
 		throw DirectReturnDemand{Utils::writeJSON(ret), "application/json"};
 	}
-	
+
 	LACTION1(PairPaymentAction, "pair_payment",
-			std::string, identifier, "number") {
+			 std::string, identifier, "number")
+	{
 		payments_mutex.lock_shared();
-		if(!payment_intents.contains(identifier)) {
+		if (!payment_intents.contains(identifier))
+		{
 			payments_mutex.unlock_shared();
 			return {false, "确认码或用户名无效"};
 		}
-		std::shared_ptr<FBUC::PaymentIntent> intent=payment_intents[identifier];
+		std::shared_ptr<FBUC::PaymentIntent> intent = payment_intents[identifier];
 		payments_mutex.unlock_shared();
-		if(intent->needs_verify) {
+		if (intent->needs_verify)
+		{
 			return {false, "用户需要完成一次官方支付以满足唯一性验证需求"};
-		}else if(intent->paired) {
+		}
+		else if (intent->paired)
+		{
 			return {false, "指定确认码已然匹配，请让用户重新结算。"};
-		}else if(intent->card_only) {
+		}
+		else if (intent->card_only)
+		{
 			return {false, "支付中存在仅官方支付商品，不能使用此方法结帐"};
 		}
-		if(*session->user->promocode_count<=0) {
+		if (*session->user->promocode_count <= 0)
+		{
 			return {false, "余额不足"};
 		}
 		std::string list;
-		for(Product *i:intent->content) {
-			list+=fmt::format("{}: ￥{}<br/>", i->product_name(), i->price());
+		for (Product *i : intent->content)
+		{
+			list += fmt::format("{}: ￥{}<br/>", i->product_name(), i->price());
 		}
-		list+=fmt::format("用户价格合计: ￥{}<br/>代理价合计: ￥{}<br/>", intent->price, intent->helper_price);
-		if(*session->user->promocode_count<intent->helper_price) {
-			return {false, "未确认。交易不能完成，因为余额不足。","list", list};
+		list += fmt::format("用户价格合计: ￥{}<br/>代理价合计: ￥{}<br/>", intent->price, intent->helper_price);
+		if (*session->user->promocode_count < intent->helper_price)
+		{
+			return {false, "未确认。交易不能完成，因为余额不足。", "list", list};
 		}
-		intent->paired=true;
-		intent->pairee=session->user->username;
-		return {true,"","list",list};
+		intent->paired = true;
+		intent->pairee = session->user->username;
+		return {true, "", "list", list};
 	}
-	
+
 	LACTION1(ApprovePaymentAction, "approve_payment",
-			std::string, identifier, "number") {
+			 std::string, identifier, "number")
+	{
 		payments_mutex.lock_shared();
-		if(!payment_intents.contains(identifier)) {
+		if (!payment_intents.contains(identifier))
+		{
 			payments_mutex.unlock_shared();
 			return {false, "确认码无效"};
 		}
-		std::shared_ptr<FBUC::PaymentIntent> intent=payment_intents[identifier];
+		std::shared_ptr<FBUC::PaymentIntent> intent = payment_intents[identifier];
 		payments_mutex.unlock_shared();
-		if(intent->needs_verify) {
+		if (intent->needs_verify)
+		{
 			return {false, "用户需要完成一次官方支付以满足唯一性验证需求"};
-		}else if(intent->card_only) {
+		}
+		else if (intent->card_only)
+		{
 			return {false, "支付中存在仅官方支付商品，不能使用此方法结帐"};
-		}else if(intent->banned_from_payment) {
+		}
+		else if (intent->banned_from_payment)
+		{
 			throw InvalidRequestDemand{"Payment-banned user"};
 		}
-		int64_t final=session->user->promocode_count-intent->helper_price;
-		if(final<0) {
+		int64_t final = session->user->promocode_count - intent->helper_price;
+		if (final < 0)
+		{
 			return {false, "余额不足"};
 		}
-		std::shared_ptr<FBUC::UserSession> targetSession=intent->session.lock();
-		if(!targetSession||intent->approved) {
+		std::shared_ptr<FBUC::UserSession> targetSession = intent->session.lock();
+		if (!targetSession || intent->approved)
+		{
 			return {false, "会话过期"};
 		}
-		session->user->promocode_count=final;
+		session->user->promocode_count = final;
 		finalizePaymentIntent(intent, targetSession->user.get(), session->user->username);
 		return {true, "Well done"};
 	}
-	
+
 	LACTION1(RedeemForFreeAction, "redeem_for_free",
-			std::string, captcha, "captcha") {
-		if(!session->verifyCaptcha(captcha)) {
+			 std::string, captcha, "captcha")
+	{
+		if (!session->verifyCaptcha(captcha))
+		{
 			return {false, "验证码错误"};
 		}
-		if(!session->payment_intent) {
+		if (!session->payment_intent)
+		{
 			return {false, "无商品"};
 		}
-		std::shared_ptr<FBUC::PaymentIntent> intent=session->payment_intent;
-		if(intent->approved) {
+		std::shared_ptr<FBUC::PaymentIntent> intent = session->payment_intent;
+		if (intent->approved)
+		{
 			return {false, "无商品"};
 		}
-		if(intent->price>0||intent->helper_price>0) {
+		if (intent->price > 0 || intent->helper_price > 0)
+		{
 			return {false, "商品需要付费，而非免费获取"};
 		}
 		finalizePaymentIntent(intent, session->user.get(), "@Free");
 		return {true};
 	}
-	
-	LACTION0(StripeCreateSessionAction, "stripe_create_session") {
-		std::shared_ptr<FBUC::PaymentIntent> intent=session->payment_intent;
-		if(!intent||intent->approved) {
+
+	LACTION0(StripeCreateSessionAction, "stripe_create_session")
+	{
+		std::shared_ptr<FBUC::PaymentIntent> intent = session->payment_intent;
+		if (!intent || intent->approved)
+		{
 			return {false, "没有有效的支付请求"};
 		}
-		if(!intent->content.size()) {
+		if (!intent->content.size())
+		{
 			throw InvalidRequestDemand{"Invalid request"};
 		}
-		if(intent->banned_from_payment) {
+		if (intent->banned_from_payment)
+		{
 			throw InvalidRequestDemand{"Payment request while being banned from payment"};
 		}
-		std::string return_url="https://api.fastbuilder.pro/api/stripe_recover?ssid=";
-		if(getenv("DEBUG")) {
-			return_url="http://127.0.0.1:8687/api/stripe_recover?ssid=";
+		std::string return_url = "https://api.fastbuilder.pro/api/stripe_recover?ssid=";
+		if (getenv("DEBUG"))
+		{
+			return_url = "http://127.0.0.1:8687/api/stripe_recover?ssid=";
 		}
-		return_url+=session->session_id;
+		return_url += session->session_id;
 		httplib::Params params{
 			//{"line_items[0][quantity]", "1"},
 			//{"line_items[0][price_data][tax_behavior]", "exclusive"},
@@ -290,40 +380,47 @@ namespace FBUC {
 			{"success_url", return_url},
 			{"cancel_url", return_url},
 			{"automatic_tax[enabled]", "true"},
-			{"consent_collection[terms_of_service]", "required"}
-		};
-		if(intent->points_delta<0) {
+			{"consent_collection[terms_of_service]", "required"}};
+		if (intent->points_delta < 0)
+		{
 			params.emplace("line_items[0][quantity]", "1");
 			params.emplace("line_items[0][price_data][tax_behavior]", "exclusive");
 			params.emplace("line_items[0][price_data][currency]", "cny");
 			params.emplace("line_items[0][price_data][product_data][name]", "Discounted Products Set");
-			params.emplace("line_items[0][price_data][unit_amount]", std::to_string(intent->stripe_price*100));
-		}else{
-			for(unsigned int i=0;i<intent->content.size();i++) {
-				Product *item=intent->content[i];
+			params.emplace("line_items[0][price_data][unit_amount]", std::to_string(intent->stripe_price * 100));
+		}
+		else
+		{
+			for (unsigned int i = 0; i < intent->content.size(); i++)
+			{
+				Product *item = intent->content[i];
 				params.emplace(fmt::format("line_items[{}][quantity]", i), "1");
 				params.emplace(fmt::format("line_items[{}][price_data][tax_behavior]", i), "exclusive");
 				params.emplace(fmt::format("line_items[{}][price_data][currency]", i), "cny");
 				params.emplace(fmt::format("line_items[{}][price_data][product_data][name]", i), item->product_name_en());
-				params.emplace(fmt::format("line_items[{}][price_data][unit_amount]", i), std::to_string(item->price()*100));
+				params.emplace(fmt::format("line_items[{}][price_data][unit_amount]", i), std::to_string(item->price() * 100));
 			}
 		}
-		stripe_retry_01: {}
-		auto stripe_res=stripeClient.Post("/v1/checkout/sessions", params);
-		if(!stripe_res) {
+	stripe_retry_01:
+	{
+	}
+		auto stripe_res = stripeClient.Post("/v1/checkout/sessions", params);
+		if (!stripe_res)
+		{
 			goto stripe_retry_01;
 		}
 		Json::Value stripe_parsed;
-		if(!Utils::parseJSON(stripe_res->body, &stripe_parsed, nullptr)) {
+		if (!Utils::parseJSON(stripe_res->body, &stripe_parsed, nullptr))
+		{
 			throw ServerErrorDemand{"Failed to parse stripe response"};
 		}
 		payments_mutex.lock();
-		payment_intents[stripe_parsed["id"].asString()]=payment_intents[session->user->username];
+		payment_intents[stripe_parsed["id"].asString()] = payment_intents[session->user->username];
 		payments_mutex.unlock();
-		intent->stripe_pid=stripe_parsed["id"].asString();
+		intent->stripe_pid = stripe_parsed["id"].asString();
 		return {true, "", "url", stripe_parsed["url"]};
 	}
-	
+
 	/*LACTION0(GetPaymentLogAction, "get_payment_log") {
 		std::shared_ptr<FBWhitelist::User> user=session->user;
 		auto client=mongodb_pool.acquire();
@@ -363,108 +460,122 @@ namespace FBUC {
 		}
 		return {true, "", "payments", ret_arr, "pages", 1};
 	}*/
-	
+
 	LACTION1(HelperChargeAction, "helper_charge",
-			uint32_t, value, "value") {
-		if(*value>=800||*value<6)
+			 uint32_t, value, "value")
+	{
+		if (*value >= 800 || *value < 6)
 			throw InvalidRequestDemand{"Invalid amount given"};
-		if(*session->user->promocode_count==0)
+		if (*session->user->promocode_count == 0)
 			throw InvalidRequestDemand{"User not permitted to charge"};
-		std::string return_url=fmt::format("https://api.fastbuilder.pro/api/stripe_recover?is_checkout=1&ssid={}", session->session_id);
-		if(getenv("DEBUG")) {
-			return_url=fmt::format("http://127.0.0.1:8687/api/stripe_recover?is_checkout=1&ssid={}", session->session_id);
+		std::string return_url = fmt::format("https://api.fastbuilder.pro/api/stripe_recover?is_checkout=1&ssid={}", session->session_id);
+		if (getenv("DEBUG"))
+		{
+			return_url = fmt::format("http://127.0.0.1:8687/api/stripe_recover?is_checkout=1&ssid={}", session->session_id);
 		}
 		httplib::Params params{
 			{"line_items[0][quantity]", "1"},
 			{"line_items[0][price_data][tax_behavior]", "exclusive"},
 			{"line_items[0][price_data][currency]", "cny"},
 			{"line_items[0][price_data][product_data][name]", "FBUC Charge"},
-			{"line_items[0][price_data][unit_amount]", std::to_string(value*100)},
+			{"line_items[0][price_data][unit_amount]", std::to_string(value * 100)},
 			{"mode", "payment"},
 			{"allow_promotion_codes", "true"},
 			{"payment_method_types[0]", "card"},
 			{"payment_method_types[1]", "alipay"},
 			{"success_url", return_url},
 			{"cancel_url", return_url},
-			{"automatic_tax[enabled]", "true"}
-		};
-		stripe_retry_02: {}
-		auto stripe_res=stripeClient.Post("/v1/checkout/sessions", params);
-		if(!stripe_res) {
+			{"automatic_tax[enabled]", "true"}};
+	stripe_retry_02:
+	{
+	}
+		auto stripe_res = stripeClient.Post("/v1/checkout/sessions", params);
+		if (!stripe_res)
+		{
 			goto stripe_retry_02;
 		}
 		Json::Value stripe_parsed;
-		if(!Utils::parseJSON(stripe_res->body, &stripe_parsed, nullptr)) {
+		if (!Utils::parseJSON(stripe_res->body, &stripe_parsed, nullptr))
+		{
 			throw ServerErrorDemand{"Failed to parse stripe response"};
 		}
-		PaymentIntent *chargeIntent=new PaymentIntent;
-		chargeIntent->session=session;
-		chargeIntent->price=801;
-		chargeIntent->stripe_price=801;
-		chargeIntent->helper_price=value;
-		chargeIntent->card_only=true;
-		auto shared_intent=std::shared_ptr<PaymentIntent>(chargeIntent);
+		PaymentIntent *chargeIntent = new PaymentIntent;
+		chargeIntent->session = session;
+		chargeIntent->price = 801;
+		chargeIntent->stripe_price = 801;
+		chargeIntent->helper_price = value;
+		chargeIntent->card_only = true;
+		auto shared_intent = std::shared_ptr<PaymentIntent>(chargeIntent);
 		payments_mutex.lock();
-		payment_intents[stripe_parsed["id"].asString()]=shared_intent;
+		payment_intents[stripe_parsed["id"].asString()] = shared_intent;
 		payments_mutex.unlock();
-		session->payment_intent=shared_intent;
+		session->payment_intent = shared_intent;
 		return {true, "created", "url", stripe_parsed["url"]};
 	}
-	
+
 	LACTION1(CheckoutUsePointsAction, "use_points_on_checkout",
-			uint32_t, value, "value") {
-		std::shared_ptr<FBUC::PaymentIntent> intent=session->payment_intent;
-		if(!intent||intent->paired||intent->approved) {
+			 uint32_t, value, "value")
+	{
+		std::shared_ptr<FBUC::PaymentIntent> intent = session->payment_intent;
+		if (!intent || intent->paired || intent->approved)
+		{
 			return {false, "没有有效的支付请求"};
 		}
-		if(!*value||!intent->content.size()) {
+		if (!*value || !intent->content.size())
+		{
 			throw InvalidRequestDemand{"Invalid request"};
 		}
-		if(intent->banned_from_payment) {
+		if (intent->banned_from_payment)
+		{
 			throw InvalidRequestDemand{"Payment request while being banned from payment"};
 		}
-		if(session->user->free&&!session->user->expiration_date.stillAlive()) {
+		if (session->user->free && !session->user->expiration_date.stillAlive())
+		{
 			throw InvalidRequestDemand{"Invalid request"};
 		}
-		if(intent->points_delta<0) {
+		if (intent->points_delta < 0)
+		{
 			return {false, "已经使用过 Points"};
 		}
-		if(*value>session->user->points)
+		if (*value > session->user->points)
 			return {false, "Points 不足"};
-		if(*value%100)
+		if (*value % 100)
 			return {false, "Points 使用不符合规则"};
-		intent->points_delta=-value;
-		uint32_t price_delta=*value/100;
-		if(price_delta>=intent->price) {
-			intent->points_delta=-(intent->price*100);
-			intent->price=0;
-			intent->helper_price=0;
-			intent->stripe_price=0;
-		}else{
-			intent->price-=price_delta;
-			intent->helper_price-=round((price_delta)*0.4);
-			intent->stripe_price-=price_delta;
-			if(intent->stripe_price<6)
-				intent->stripe_price=6;
+		intent->points_delta = -value;
+		uint32_t price_delta = *value / 100;
+		if (price_delta >= intent->price)
+		{
+			intent->points_delta = -(intent->price * 100);
+			intent->price = 0;
+			intent->helper_price = 0;
+			intent->stripe_price = 0;
+		}
+		else
+		{
+			intent->price -= price_delta;
+			intent->helper_price -= round((price_delta) * 0.4);
+			intent->stripe_price -= price_delta;
+			if (intent->stripe_price < 6)
+				intent->stripe_price = 6;
 		}
 		return {true, "Perfect"};
 	}
-	
+
 	static FBUCActionCluster marketplaceGeneralActions(0, {
-		Action::enmap(new GetProductListAction),
-		Action::enmap(new AddProductToCartAction),
-		Action::enmap(new GetShoppingCartAction),
-		Action::enmap(new EraseFromShoppingCartAction),
-		Action::enmap(new GenerateBillAction),
-		Action::enmap(new GetBillAction),
-		Action::enmap(new CheckPaymentAction),
-		Action::enmap(new UCGetBalanceAction),
-		Action::enmap(new PairPaymentAction),
-		Action::enmap(new ApprovePaymentAction),
-		Action::enmap(new HelperChargeAction),
-		Action::enmap(new CheckoutUsePointsAction),
-		Action::enmap(new RedeemForFreeAction),
-		Action::enmap(new StripeCreateSessionAction)
-		//Action::enmap(new GetPaymentLogAction) -> db_related.cpp
-	});
+															  Action::enmap(new GetProductListAction),
+															  Action::enmap(new AddProductToCartAction),
+															  Action::enmap(new GetShoppingCartAction),
+															  Action::enmap(new EraseFromShoppingCartAction),
+															  Action::enmap(new GenerateBillAction),
+															  Action::enmap(new GetBillAction),
+															  Action::enmap(new CheckPaymentAction),
+															  Action::enmap(new UCGetBalanceAction),
+															  Action::enmap(new PairPaymentAction),
+															  Action::enmap(new ApprovePaymentAction),
+															  Action::enmap(new HelperChargeAction),
+															  Action::enmap(new CheckoutUsePointsAction),
+															  Action::enmap(new RedeemForFreeAction),
+															  Action::enmap(new StripeCreateSessionAction)
+															  // Action::enmap(new GetPaymentLogAction) -> db_related.cpp
+														  });
 };

--- a/modules/user_center/actions/phoenix_client.cpp
+++ b/modules/user_center/actions/phoenix_client.cpp
@@ -1,215 +1,664 @@
 #include "../user_center.h"
+#define CPPHTTPLIB_OPENSSL_SUPPORT
+#include "cpp-httplib/httplib.h"
 #include "utils.h"
 #include "secrets.h"
 #include <fmt/format.h>
 #include <spdlog/spdlog.h>
+extern httplib::Client dotcsClient;
+extern httplib::Headers DotCS_Headers;
+std::string get_check_num(std::string const &data);
 
-std::string get_check_num(std::string const& data);
-
-namespace FBUC {
+namespace FBUC
+{
 	ACTION6(PhoenixLoginAction, "phoenix/login",
 			std::optional<std::string>, login_token, "login_token",
 			std::optional<std::string>, _username, "username",
 			std::optional<std::string>, _password, "password",
 			std::string, server_code, "server_code",
 			std::string, server_passcode, "server_passcode",
-			std::string, client_public_key, "client_public_key") {
-		if(session->user) {
+			std::string, client_public_key, "client_public_key")
+	{
+		if (session->user)
+		{
 			throw InvalidRequestDemand{"Already logged in"};
 		}
 		std::string username;
 		std::string password;
-		if(!login_token->has_value()) {
-			if(!_username->has_value()||!_password->has_value()) {
+		if (!login_token->has_value())
+		{
+			if (!_username->has_value() || !_password->has_value())
+			{
 				throw InvalidRequestDemand{"Insufficient arguments"};
 			}
-			username=**_username;
-			//password=Utils::sha256(Secrets::addSalt(**_password));
-			password=**_password;
-		}else{
-			if(_username->has_value()) {
+			username = **_username;
+			// password=Utils::sha256(Secrets::addSalt(**_password));
+			password = **_password;
+		}
+		else
+		{
+			if (_username->has_value())
+			{
 				throw InvalidRequestDemand{"Conflicted arguments"};
 			}
 			Json::Value token_content;
-			bool parsed=Utils::parseJSON(FBToken::decrypt(**login_token), &token_content, nullptr);
-			if(!parsed||!token_content["username"].isString()||!token_content["password"].isString()||!token_content["newToken"].asBool()) {
+			bool parsed = Utils::parseJSON(FBToken::decrypt(**login_token), &token_content, nullptr);
+			if (!parsed || !token_content["username"].isString() || !token_content["password"].isString() || !token_content["newToken"].asBool())
+			{
 				return {false, "Invalid token"};
 			}
-			username=token_content["username"].asString();
-			password=token_content["password"].asString();
+			username = token_content["username"].asString();
+			password = token_content["password"].asString();
 		}
-		std::shared_ptr<FBWhitelist::User> pUser=FBWhitelist::Whitelist::acquireUser(username);
-		if(!pUser) {
+		std::shared_ptr<FBWhitelist::User> pUser = FBWhitelist::Whitelist::acquireUser(username);
+		if (!pUser)
+		{
 			return {false, "无效用户名或一次性密码，注意: 为防止账号盗用，您不再能够使用用户中心的密码登录 PhoenixBuilder ，请使用 FBToken 或用户中心一次性密码登录。"};
 		}
-		if(!pUser->disable_all_security_measures) {
-			if(login_token->has_value()) {
-				if(!pUser||pUser->password!=password) {
+		if (!pUser->disable_all_security_measures)
+		{
+			if (login_token->has_value())
+			{
+				if (!pUser || pUser->password != password)
+				{
 					return {false, "Invalid username or password"};
 				}
-			}else{
-				if(!pUser||Utils::sha256(pUser->phoenix_login_otp)!=password) {
+			}
+			else
+			{
+				if (!pUser || Utils::sha256(pUser->phoenix_login_otp) != password)
+				{
 					return {false, "无效用户名或一次性密码，注意: 为防止账号盗用，您不再能够使用用户中心的密码登录 PhoenixBuilder ，请使用 FBToken 或用户中心一次性密码登录。"};
 				}
-				pUser->phoenix_login_otp=Utils::generateUUID();
+				pUser->phoenix_login_otp = Utils::generateUUID();
 			}
-		}else{
-			if(!login_token->has_value())
-				password=Utils::sha256(Secrets::addSalt(**_password));
-			if(!pUser||pUser->password!=password) {
+		}
+		else
+		{
+			if (!login_token->has_value())
+				password = Utils::sha256(Secrets::addSalt(**_password));
+			if (!pUser || pUser->password != password)
+			{
 				return {false, "Invalid username or password"};
 			}
 		}
-		auto user=pUser;
-		if(user->free&&!user->expiration_date.stillAlive()) {
+
+		auto user = pUser;
+		if (!user->isDotCS)
+		{
+			SPDLOG_INFO("Phoenix login (rejected): {} -> {} [no dotcs power] IP: {}", *user->username, *server_code, session->ip_address);
+			return {false, "此账户已绑定DotCS,您无法使用本账户登录 FastBuilder APP"};
+		}
+		if (user->free && !user->expiration_date.stillAlive())
+		{
 			SPDLOG_INFO("Phoenix login (rejected): {} -> {} [no payment] IP: {}", *user->username, *server_code, session->ip_address);
 			return {false, "月额 Plan 失效已过或从未激活，请前往用户中心购买。"};
 		}
-		if(server_code=="::DRY::"&&server_passcode=="::DRY::") {
+		if (server_code == "::DRY::" && server_passcode == "::DRY::")
+		{
 			SPDLOG_INFO("Phoenix login (passed - dry): {}, IP: {}", *user->username, session->ip_address);
 			std::string pubKey;
-			if(!user->signing_key.has_value()) {
-				auto keyPair=Utils::generateRSAKeyPair();
+			if (!user->signing_key.has_value())
+			{
+				auto keyPair = Utils::generateRSAKeyPair();
 				FBWhitelist::SigningKeyPair skp;
-				skp.private_key=keyPair.first;
-				skp.public_key=keyPair.second;
-				pubKey=keyPair.second;
-				user->signing_key=skp;
-			}else{
-				pubKey=(std::string)user->signing_key->public_key;
+				skp.private_key = keyPair.first;
+				skp.public_key = keyPair.second;
+				pubKey = keyPair.second;
+				user->signing_key = skp;
 			}
-			std::string privateSigningKeyProve=fmt::format("{}|{}", pubKey, *user->username);
+			else
+			{
+				pubKey = (std::string)user->signing_key->public_key;
+			}
+			std::string privateSigningKeyProve = fmt::format("{}|{}", pubKey, *user->username);
 			privateSigningKeyProve.append(fmt::format("::{}", Utils::cv4Sign(privateSigningKeyProve)));
-			session->user=pUser;
-			session->phoenix_only=true;
-			std::string rettoken="";
-			if(!login_token->has_value()) {
+			session->user = pUser;
+			session->phoenix_only = true;
+			std::string rettoken = "";
+			if (!login_token->has_value())
+			{
 				Json::Value token;
-				token["username"]=username;
-				token["password"]=pUser->password;
-				token["newToken"]=true;
-				rettoken=FBToken::encrypt(token);
+				token["username"] = username;
+				token["password"] = pUser->password;
+				token["newToken"] = true;
+				rettoken = FBToken::encrypt(token);
 			}
 			std::string respond_to;
-			if(user->cn_username.has_value()) {
-				respond_to=user->cn_username;
+			if (user->cn_username.has_value())
+			{
+				respond_to = user->cn_username;
 			}
 			return {true, "well done", "dry", true, "privateSigningKey", user->signing_key->private_key, "prove", privateSigningKeyProve, "token", rettoken, "respond_to", respond_to};
 		}
-		if(!user->nemc_access_info.has_value()) {
+		if (!user->nemc_access_info.has_value())
+		{
 			SPDLOG_INFO("Phoenix login (rejected): {} -> {} [no helper] IP: {}", *user->username, *server_code, session->ip_address);
 			return {false, "未创建辅助用户，请前往用户中心创建。", "translation", 7};
 		}
-		bool approved=false;
-		if(!user->isAdministrator) {
-			if(!approved&&user->rentalservers.size()) {
-				for(auto const& ind:user->rentalservers) {
-					if(*ind.second.content==*server_code) {
-						approved=true;
+		bool approved = false;
+		if (!user->isAdministrator)
+		{
+			if (!approved && user->rentalservers.size())
+			{
+				for (auto const &ind : user->rentalservers)
+				{
+					if (*ind.second.content == *server_code)
+					{
+						approved = true;
 						break;
 					}
 				}
 			}
-			if(!approved&&!user->isCommercial) {
+			if (!approved && !user->isCommercial)
+			{
 				SPDLOG_INFO("Phoenix login (rejected): {} -> {} [unauthorized server code] IP: {}", *user->username, *server_code, session->ip_address);
 				return {false, "指定的租赁服号未授权，请前往用户中心设置", "translation", 13};
 			}
 		}
 		NEMCUser nemcUser;
-		if(user->nemc_temp_info.has_value()) {
-			nemcUser=user->nemc_temp_info;
+		if (user->nemc_temp_info.has_value())
+		{
+			nemcUser = user->nemc_temp_info;
 		}
-		if(!nemcUser.isLoggedIn()) {
-			try {
-				nemcUser=user->nemc_access_info->auth();
-				user->nemc_temp_info=nemcUser;
-			}catch(NEMCError const& err) {
+		if (!nemcUser.isLoggedIn())
+		{
+			try
+			{
+				nemcUser = user->nemc_access_info->auth();
+				user->nemc_temp_info = nemcUser;
+			}
+			catch (NEMCError const &err)
+			{
 				SPDLOG_INFO("Phoenix login (rejected): {} -> {} [nemc error: {}] IP: {}", *user->username, *server_code, err.description, session->ip_address);
-				return {false, err.description, "translation", err.translation>0?err.translation:-1};
+				return {false, err.description, "translation", err.translation > 0 ? err.translation : -1};
 			}
 		}
 		std::string helperun;
-		try {
-			helperun=nemcUser.getUsername();
-		}catch(NEMCError const& err) {
-			SPDLOG_INFO("Phoenix login (rejected): {} -> {} [nemc error: {}] IP: {}", *user->username, *server_code, err.description, session->ip_address);
-			return {false, err.description, "translation", err.translation>0?err.translation:-1};
+		try
+		{
+			helperun = nemcUser.getUsername();
 		}
-		if(helperun.size()==0) {
+		catch (NEMCError const &err)
+		{
+			SPDLOG_INFO("Phoenix login (rejected): {} -> {} [nemc error: {}] IP: {}", *user->username, *server_code, err.description, session->ip_address);
+			return {false, err.description, "translation", err.translation > 0 ? err.translation : -1};
+		}
+		if (helperun.size() == 0)
+		{
 			SPDLOG_INFO("Phoenix login (rejected): {} -> {} [helper no username] IP: {}", *user->username, *server_code, session->ip_address);
 			return {false, "辅助用户用户名设置无效，请前往用户中心重新设置", "translation", 9};
 		}
 		std::pair<std::string, std::string> chainInfo;
-		try {
-			chainInfo=nemcUser.doImpact(server_code, server_passcode, client_public_key, helperun);
-		}catch(NEMCError const& err) {
+		try
+		{
+			chainInfo = nemcUser.doImpact(server_code, server_passcode, client_public_key, helperun);
+		}
+		catch (NEMCError const &err)
+		{
 			SPDLOG_INFO("Phoenix login (rejected): {} -> {} [nemc error: {}] IP: {}", *user->username, *server_code, err.description, session->ip_address);
-			return {false, err.description, "translation", err.translation>0?err.translation:-1};
+			return {false, err.description, "translation", err.translation > 0 ? err.translation : -1};
 		}
 		SPDLOG_INFO("Phoenix login (passed): {} -> {}, Helper: {}, IP: {}", *user->username, *server_code, helperun, session->ip_address);
 		std::string pubKey;
-		if(!user->signing_key.has_value()) {
-			auto keyPair=Utils::generateRSAKeyPair();
+		if (!user->signing_key.has_value())
+		{
+			auto keyPair = Utils::generateRSAKeyPair();
 			FBWhitelist::SigningKeyPair skp;
-			skp.private_key=keyPair.first;
-			skp.public_key=keyPair.second;
-			pubKey=keyPair.second;
-			user->signing_key=skp;
-		}else{
-			pubKey=(std::string)user->signing_key->public_key;
+			skp.private_key = keyPair.first;
+			skp.public_key = keyPair.second;
+			pubKey = keyPair.second;
+			user->signing_key = skp;
 		}
-		std::string privateSigningKeyProve=fmt::format("{}|{}", pubKey, *user->username);
+		else
+		{
+			pubKey = (std::string)user->signing_key->public_key;
+		}
+		std::string privateSigningKeyProve = fmt::format("{}|{}", pubKey, *user->username);
 		privateSigningKeyProve.append(fmt::format("::{}", Utils::cv4Sign(privateSigningKeyProve)));
-		session->user=pUser;
-		session->phoenix_only=true;
-		std::string rettoken="";
-		if(!login_token->has_value()) {
+		session->user = pUser;
+		session->phoenix_only = true;
+		std::string rettoken = "";
+		if (!login_token->has_value())
+		{
 			Json::Value token;
-			token["username"]=username;
-			token["password"]=pUser->password;
-			token["newToken"]=true;
-			rettoken=FBToken::encrypt(token);
+			token["username"] = username;
+			token["password"] = pUser->password;
+			token["newToken"] = true;
+			rettoken = FBToken::encrypt(token);
 		}
 		std::string respond_to;
-		if(user->cn_username.has_value()) {
-			respond_to=user->cn_username;
+		if (user->cn_username.has_value())
+		{
+			respond_to = user->cn_username;
 		}
 		return {true, "well done", "chainInfo", chainInfo.first, "ip_address", chainInfo.second, "uid", nemcUser.getUID(), "username", helperun, "privateSigningKey", user->signing_key->private_key, "prove", privateSigningKeyProve, "token", rettoken, "respond_to", respond_to};
 	}
+
+	 ACTION6(DotCS_APP_LoginAction, "dotcs/login",
+		std::optional<std::string>, login_token, "login_token",
+		std::optional<std::string>, _username, "username",
+		std::optional<std::string>, _password, "password",
+		std::string, _server_code, "server_code",
+		std::string, _server_passcode, "server_passcode",
+		std::string, client_public_key, "client_public_key") {
 	
+	 	if(session->user) {
+	 		throw InvalidRequestDemand{"Already logged in"};
+	 	}
+	  	std::string username;
+	  	std::string password;
+	  	std::string server_code;
+	  	std::string server_passcode;
+	  	bool is_token_login_mode=false;
+	  	if(!login_token->has_value()) {
+	  		if(!_username->has_value()||!_password->has_value()) {
+	  			throw InvalidRequestDemand{"Insufficient arguments"};
+	  		}
+	  		username=**_username;
+	  		//password=Utils::sha256(Secrets::addSalt(**_password));
+	  		password=**_password;
+	  	}else{
+	  		if(_username->has_value()) {
+	  			throw InvalidRequestDemand{"Conflicted arguments"};
+	  		}
+	  		bool is_token_login_mode=false;
+			username="__token__";
+	  		password=**login_token;
+	  		}
+	  	server_code = _server_code;
+	  	server_passcode = _server_passcode;
+	  	Json::Value login_packet;
+	  	login_packet["username"] = username;
+	  	login_packet["password"] = password;
+	  	login_packet["server_code"] = server_code;
+	  	login_packet["server_passcode"] = server_passcode;
+		login_packet["ip"] = session->ip_address;
+	 	Json::StreamWriterBuilder writebuild;
+	 	writebuild["emitUTF8"] = true;
+	 	std::string login_text = Json::writeString(writebuild, login_packet);
+
+
+		// 辅助用户部分未测试
+	 	if (auto res = dotcsClient.Post("/fbuc_api/fb_app_login", DotCS_Headers, login_text, "application/json"))
+	 	{
+	 		if (res->status == 200)
+	 		{
+	
+	 			Json::CharReaderBuilder ReaderBuilder;
+	 			ReaderBuilder["emitUTF8"] = true;
+	 			std::unique_ptr<Json::CharReader> charread(ReaderBuilder.newCharReader());
+	 			std::string data = res->body;
+	 			Json::Value root;
+	 			std::string strerr;
+	 			bool isok = charread->parse(data.c_str(), data.c_str() + data.size(), &root, &strerr);
+	 			if (!isok || strerr.size() != 0)
+	 			{
+	 				return {false, "DotCS验证服务器的消息解析失败,可能是DotCS服务器未开启此接口。"};
+	 			}
+	 			bool success = root.get("success", false).asBool();
+	 			if (success == true)
+	 			{
+	 				std::string fb_username = root.get("fb_name", "").asString();
+	 				if (fb_username == "")
+	 				{
+	 					return {false, "FastBuilder未能成功获取到DotCS用户信息,请联系 DotCS 解决。"};
+	 				}
+	 				std::shared_ptr<FBWhitelist::User> pUser = FBWhitelist::Whitelist::acquireUser(fb_username);
+	 				if (!pUser)
+	 				{
+	 					SPDLOG_INFO("User Center login (rejected-dotcs): Username: {}, IP: {}", fb_username, session->ip_address);
+	 					return {false, "无效的FastBuilder账户"};
+	 				}
+	 				if (!pUser->isDotCS)
+	 				{
+	 					SPDLOG_INFO("User Center login (rejected-dotcs): Username: {}, IP: {}", fb_username, session->ip_address);
+	 					return {false, "此账户在FastBuilder的记录中尚未绑定,请联系FastBuilder管理员进行绑定。"};
+	 				}
+	 				else
+	 				{
+						if (server_code == "::DRY::" && server_passcode == "::DRY::")
+						{
+							SPDLOG_INFO("Phoenix login (passed - dry): {}, IP: {}", pUser->username, session->ip_address);
+							std::string pubKey;
+							if (!pUser->signing_key.has_value())
+							{
+								auto keyPair = Utils::generateRSAKeyPair();
+								FBWhitelist::SigningKeyPair skp;
+								skp.private_key = keyPair.first;
+								skp.public_key = keyPair.second;
+								pubKey = keyPair.second;
+								pUser->signing_key = skp;
+							}
+							else
+							{
+								pubKey = (std::string)pUser->signing_key->public_key;
+							}
+							std::string privateSigningKeyProve = fmt::format("{}|{}", pubKey, pUser->username);
+							privateSigningKeyProve.append(fmt::format("::{}", Utils::cv4Sign(privateSigningKeyProve)));
+							session->user = pUser;
+							session->phoenix_only = true;
+							std::string rettoken = "";
+							if (!login_token->has_value())
+							{
+								Json::Value token;
+								token["username"] = username;
+								token["password"] = pUser->password;
+								token["newToken"] = true;
+								rettoken = FBToken::encrypt(token);
+							}
+							std::string respond_to;
+							if (pUser->cn_username.has_value())
+							{
+								respond_to = pUser->cn_username;
+							}
+							return {true, "well done", "dry", true, "privateSigningKey", pUser->signing_key->private_key, "prove", privateSigningKeyProve, "token", rettoken, "respond_to", respond_to};
+						}
+						if (!pUser->nemc_access_info.has_value())
+						{
+							SPDLOG_INFO("Phoenix login (rejected): {} -> {} [no helper] IP: {}", pUser->username, server_code, session->ip_address);
+							return {false, "未创建辅助用户，请前往FastBuilder 用户中心创建。", "translation", 7};
+						}
+						NEMCUser nemcUser;
+						if (pUser->nemc_temp_info.has_value())
+						{
+							nemcUser = pUser->nemc_temp_info;
+						}
+						if (!nemcUser.isLoggedIn())
+						{
+							try
+							{
+								nemcUser = pUser->nemc_access_info->auth();
+								pUser->nemc_temp_info = nemcUser;
+							}
+							catch (NEMCError const &err)
+							{
+								SPDLOG_INFO("Phoenix login (rejected): {} -> {} [nemc error: {}] IP: {}", pUser->username, server_code, err.description, session->ip_address);
+								return {false, err.description, "translation", err.translation > 0 ? err.translation : -1};
+							}
+						}
+						std::string helperun;
+						try
+						{
+							helperun = nemcUser.getUsername();
+						}
+						catch (NEMCError const &err)
+						{
+							SPDLOG_INFO("Phoenix login (rejected): {} -> {} [nemc error: {}] IP: {}", pUser->username, server_code, err.description, session->ip_address);
+							return {false, err.description, "translation", err.translation > 0 ? err.translation : -1};
+						}
+						if (helperun.size() == 0)
+						{
+							SPDLOG_INFO("Phoenix login (rejected): {} -> {} [helper no username] IP: {}", pUser->username, server_code, session->ip_address);
+							return {false, "辅助用户用户名设置无效，请前往用户中心重新设置", "translation", 9};
+						}
+						std::pair<std::string, std::string> chainInfo;
+						try
+						{
+							chainInfo = nemcUser.doImpact(server_code, server_passcode, client_public_key, helperun);
+						}
+						catch (NEMCError const &err)
+						{
+							SPDLOG_INFO("Phoenix login (rejected): {} -> {} [nemc error: {}] IP: {}", pUser->username, server_code, err.description, session->ip_address);
+							return {false, err.description, "translation", err.translation > 0 ? err.translation : -1};
+						}
+						SPDLOG_INFO("Phoenix login (passed): {} -> {}, Helper: {}, IP: {}", pUser->username, server_code, helperun, session->ip_address);
+						std::string pubKey;
+						if (!pUser->signing_key.has_value())
+						{
+							auto keyPair = Utils::generateRSAKeyPair();
+							FBWhitelist::SigningKeyPair skp;
+							skp.private_key = keyPair.first;
+							skp.public_key = keyPair.second;
+							pubKey = keyPair.second;
+							pUser->signing_key = skp;
+						}
+						else
+						{
+							pubKey = (std::string)pUser->signing_key->public_key;
+						}
+						std::string privateSigningKeyProve = fmt::format("{}|{}", pubKey, pUser->username);
+						privateSigningKeyProve.append(fmt::format("::{}", Utils::cv4Sign(privateSigningKeyProve)));
+						session->user = pUser;
+						session->phoenix_only = true;
+						std::string rettoken = "";
+						if (!login_token->has_value())
+						{
+							Json::Value token;
+							token["username"] = username;
+							token["password"] = pUser->password;
+							token["newToken"] = true;
+							rettoken = FBToken::encrypt(token);
+						}
+						std::string respond_to;
+						if (pUser->cn_username.has_value())
+						{
+							respond_to = pUser->cn_username;
+						}
+						return {true, "well done", "chainInfo", chainInfo.first, "ip_address", chainInfo.second, "uid", nemcUser.getUID(), "username", helperun, "privateSigningKey", pUser->signing_key->private_key, "prove", privateSigningKeyProve, "token", rettoken, "respond_to", respond_to};
+	 				}
+	 			}
+	 			else
+	 			{
+	 				return {false, root.get("message", "未知DotCS验证服务器错误").asString()};
+	 			}
+	 		}
+	 		else
+	 		{
+	 			return {false, "DotCS验证服务器无法服务或验证未通过"};
+	 		}
+	 	}
+	 	else
+	 	{
+	 		return {false, "DotCS验证服务器暂时无法访问,请等待恢复"};
+	 	}
+
+
+
+
+
+
+
+
+
+
+
+
+
+		}
+	// ACTION6(PhoenixLoginAction, "dotcs/login",
+	// 		std::optional<std::string>, login_token, "login_token",
+	// 		std::optional<std::string>, _username, "username",
+	// 		std::optional<std::string>, _password, "password",
+	// 		std::string, server_code, "server_code",
+	// 		std::string, server_passcode, "server_passcode",
+	// 		std::string, client_public_key, "client_public_key") {
+	// 	if(session->user) {
+	// 		throw InvalidRequestDemand{"Already logged in"};
+	// 	}
+	// 	std::string username;
+	// 	std::string password;
+	// 	bool is_token_login_mode=false;
+	// 	if(!login_token->has_value()) {
+	// 		if(!_username->has_value()||!_password->has_value()) {
+	// 			throw InvalidRequestDemand{"Insufficient arguments"};
+	// 		}
+	// 		username=**_username;
+	// 		//password=Utils::sha256(Secrets::addSalt(**_password));
+	// 		password=**_password;
+	// 	}else{
+	// 		if(_username->has_value()) {
+	// 			throw InvalidRequestDemand{"Conflicted arguments"};
+	// 		}
+	// 		bool is_token_login_mode=false;
+	// 		Json::Value token_content;
+	// 		bool parsed=Utils::parseJSON(FBToken::decrypt(**login_token), &token_content, nullptr);
+	// 		if(!parsed||!token_content["username"].isString()||!token_content["password"].isString()||!token_content["newToken"].asBool()) {
+	// 			return {false, "Invalid token"};
+	// 		}
+	// 		username="__token__";
+	// 		password=**login_token;
+	// 		}
+	// 	Json::Value login_packet;
+	// 	login_packet["username"] = username;
+	// 	login_packet["password"] = password;
+	 //
+	// 	Json::StreamWriterBuilder writebuild;
+	// 	writebuild["emitUTF8"] = true;
+	// 	std::string login_text = Json::writeString(writebuild, login_packet);
+	// 	if (auto res = dotcsClient.Post("/fbuc_api/fb_app_login", DotCS_Headers, login_text, "application/json"))
+	// 	{
+	// 		if (res->status == 200)
+	// 		{
+	 //
+	// 			Json::CharReaderBuilder ReaderBuilder;
+	// 			ReaderBuilder["emitUTF8"] = true;
+	// 			std::unique_ptr<Json::CharReader> charread(ReaderBuilder.newCharReader());
+	// 			std::string data = res->body;
+	// 			Json::Value root;
+	// 			std::string strerr;
+	// 			bool isok = charread->parse(data.c_str(), data.c_str() + data.size(), &root, &strerr);
+	// 			if (!isok || strerr.size() != 0)
+	// 			{
+	// 				return {false, "DotCS验证服务器的消息解析失败,可能是DotCS服务器未开启此接口。"};
+	// 			}
+	// 			bool success = root.get("success", false).asBool();
+	// 			if (success == true)
+	// 			{
+	// 				std::string fb_username = root.get("fb_name", "").asString();
+	// 				if (fb_username == "")
+	// 				{
+	// 					return {false, "FastBuilder未能成功获取到DotCS用户信息,请联系 DotCS 解决。"};
+	// 				}
+	// 				std::shared_ptr<FBWhitelist::User> pUser = FBWhitelist::Whitelist::acquireUser(fb_username);
+	// 				if (!pUser)
+	// 				{
+	// 					SPDLOG_INFO("User Center login (rejected-dotcs): Username: {}, IP: {}", fb_username, session->ip_address);
+	// 					return {false, "无效的FastBuilder账户","translation"};
+	// 				}
+	// 				else if (pUser->DotCS_User_Name != username)
+	// 				{
+	// 					SPDLOG_INFO("User Center login (rejected-dotcs): Username: {}, IP: {}", fb_username, session->ip_address);
+	// 					return {false, "此账户绑定的FastBuilder用户名与FastBuilder所记载的不一致。如果您的DotCS用户名或FastBuilder用户名被更改了,可联系另一个平台的管理员进行更正"};
+	// 				}
+	// 				if (!pUser->isDotCS)
+	// 				{
+	// 					SPDLOG_INFO("User Center login (rejected-dotcs): Username: {}, IP: {}", fb_username, session->ip_address);
+	// 					return {false, "此账户在FastBuilder的记录中尚未绑定,请联系FastBuilder管理员进行绑定。"};
+	// 				}
+	// 				else
+	// 				{
+	// 					FBWhitelist::User *rawUser = pUser.get();
+	// 					if (user_unique_map.contains(rawUser))
+	// 					{
+	// 						userlist_mutex.lock();
+	// 						userlist.erase(user_unique_map[rawUser]);
+	// 						user_unique_map[rawUser] = session->session_id;
+	// 						userlist_mutex.unlock();
+	// 					}
+	// 					else
+	// 					{
+	// 						userlist_mutex.lock();
+	// 						user_unique_map[rawUser] = session->session_id;
+	// 						userlist_mutex.unlock();
+	// 					}
+	// 					session->user = pUser;
+	// 					std::string user_theme = pUser->preferredtheme.has_value() ? (*pUser->preferredtheme) : "bootstrap";
+	// 					session->token_login = false;
+	// 					session->phoenix_only = false;
+	// 					*pUser->keep_reference = true;
+	// 					if(server_code=="::DRY::"&&server_passcode=="::DRY::") {
+	// 						SPDLOG_INFO("Phoenix login (DotCS APP) (passed - dry): {}, IP: {}", fb_username, session->ip_address);
+	// 						std::string pubKey;
+	// 						if(!user->signing_key.has_value()) {
+	// 							auto keyPair=Utils::generateRSAKeyPair();
+	// 							FBWhitelist::SigningKeyPair skp;
+	// 							skp.private_key=keyPair.first;
+	// 							skp.public_key=keyPair.second;
+	// 							pubKey=keyPair.second;
+	// 							user->signing_key=skp;
+	// 						}else{
+	// 							pubKey=(std::string)user->signing_key->public_key;
+	// 						}
+	// 						std::string privateSigningKeyProve=fmt::format("{}|{}", pubKey, fb_username);
+	// 						privateSigningKeyProve.append(fmt::format("::{}", Utils::cv4Sign(privateSigningKeyProve)));
+	// 						session->user=pUser;
+	// 						session->phoenix_only=true;
+	// 						std::string rettoken="";
+	// 						if(!login_token->has_value()) {
+	// 							Json::Value token;
+	// 							token["username"]=username;
+	// 							token["password"]=pUser->password;
+	// 							token["newToken"]=true;
+	// 							rettoken=FBToken::encrypt(token);
+	// 						}
+	// 						std::string respond_to;
+	// 						if(user->cn_username.has_value()) {
+	// 							respond_to=user->cn_username;
+	// 						}
+	// 						return {true, "well done", "dry", true, "privateSigningKey", user->signing_key->private_key, "prove", privateSigningKeyProve, "token", rettoken, "respond_to", respond_to};
+	// 					}
+	// 					if(!pUser->nemc_access_info.has_value()) {
+	// 						SPDLOG_INFO("Phoenix login (DotCS APP)(rejected): {} -> {} [no helper] IP: {}", fb_username, *server_code, session->ip_address);
+	// 						return {false, "未创建辅助用户，请前往幻梦互联用户中心创建。", "translation", -1};
+	// 					}
+	// 					return {false, "测试消息", "translation", -1};
+	// 					//SPDLOG_INFO("User Center login (passed-dotcs): Username: {}, IP: {}", fb_username, session->ip_address);
+	// 					//return {true, "Welcome", "theme", user_theme, "isadmin", *pUser->isAdministrator};
+	// 				}
+	// 			}
+	// 			else
+	// 			{
+	// 				return {false, root.get("message", "未知DotCS验证服务器错误").asString()};
+	// 			}
+	// 		}
+	// 		else
+	// 		{
+	// 			return {false, "DotCS验证服务器无法服务或验证未通过"};
+	// 		}
+	// 	}
+	// 	else
+	// 	{
+	// 		return {false, "DotCS验证服务器暂时无法访问,请等待恢复"};
+	// 	}
+	// }
 	LACTION1(PhoenixTransferStartTypeAction, "phoenix/transfer_start_type",
-			std::string, content, "content") {
-		if(!session->user->nemc_temp_info.has_value()) {
+			 std::string, content, "content")
+	{
+		if (!session->user->nemc_temp_info.has_value())
+		{
 			throw ServerErrorDemand{"No login found"};
 		}
 		return {true, "", "data", NEMCCalculateStartType(content, session->user->nemc_temp_info->getUID())};
 	}
-	
+
 	LACTION1(PhoenixTransferChecknumAction, "phoenix/transfer_check_num",
-			std::string, data, "data") {
-		auto v=get_check_num(data);
-		if(!v.length()) {
+			 std::string, data, "data")
+	{
+		auto v = get_check_num(data);
+		if (!v.length())
+		{
 			return {false, "Failed"};
 		}
 		return {true, "Perfect", "value", v};
 	}
-	
-	LACTION0(GetPhoenixTokenAction, "get_phoenix_token") {
+
+	LACTION0(GetPhoenixTokenAction, "get_phoenix_token")
+	{
 		DirectReturnDemand d;
-		d.type="text/plain";
+		d.type = "text/plain";
 		Json::Value token;
-		token["username"]=session->user->username;
-		token["password"]=session->user->password;
-		token["newToken"]=true;
-		d.content=FBToken::encrypt(token);
-		d.disposition="attachment;filename=fbtoken";
+		token["username"] = session->user->username;
+		token["password"] = session->user->password;
+		token["newToken"] = true;
+		d.content = FBToken::encrypt(token);
+		d.disposition = "attachment;filename=fbtoken";
 		throw d;
 	}
-	
-	static FBUCActionCluster phoenixClientActions(0, {
-		Action::enmap(new PhoenixLoginAction),
-		Action::enmap(new PhoenixTransferStartTypeAction),
-		Action::enmap(new PhoenixTransferChecknumAction),
-		Action::enmap(new GetPhoenixTokenAction)
-	});
+
+	static FBUCActionCluster phoenixClientActions(0, {Action::enmap(new PhoenixLoginAction),
+													  Action::enmap(new DotCS_APP_LoginAction),
+													  Action::enmap(new PhoenixTransferStartTypeAction),
+													  Action::enmap(new PhoenixTransferChecknumAction),
+													  Action::enmap(new GetPhoenixTokenAction)});
 };

--- a/modules/user_center/user_center.cpp
+++ b/modules/user_center/user_center.cpp
@@ -33,7 +33,7 @@ httplib::Headers DotCS_Headers {
 	{"dlfaps","123456"} //DotCS Key(别想了,源代码里面写的Key是错误的)
 };
 httplib::Client stripeClient("https://api.stripe.com");
-httplib::Client dotcsClient("192.168.1.11",21512);
+httplib::Client dotcsClient("192.168.1.11",21512);// DotCS 服务器的地址,这里是测试地址。
 void FBUC::finalizePaymentIntent(std::shared_ptr<FBUC::PaymentIntent> intent, FBWhitelist::User *user, std::string const& helper_name) {
 	auto pSession=intent->session.lock();
 	if(pSession) {

--- a/modules/whitelist/whitelist.h
+++ b/modules/whitelist/whitelist.h
@@ -188,6 +188,8 @@ namespace FBWhitelist {
 		DBValue<NEMCUserAuthInfo> nemc_binded_account="nemc_binded_account";
 		DBValue<std::string> phoenix_login_otp="phoenix_login_otp";
 		DBValue<bool> disable_all_security_measures="disable_all_security_measures";
+		DBValue<std::string> DotCS_User_Name="DotCS_User_Name";
+		DBValue<bool> isDotCS="isDotCS";
 		std::shared_ptr<uint32_t> rate_limit_counter=std::make_shared<uint32_t>(0);
 		std::shared_ptr<bool> keep_reference=std::make_shared<bool>(false);
 		

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,7 +33,7 @@ typedef sig_t sighandler_t;
 #endif
 
 mongocxx::instance mongodb_instance;
-mongocxx::pool mongodb_pool{mongocxx::uri{"mongodb://127.0.0.1:27017"}};
+mongocxx::pool mongodb_pool{mongocxx::uri{"mongodb://192.168.1.11:27017"}};
 
 //bool rescue_mode=false;
 //std::string rescue_mode_cause;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,7 +33,7 @@ typedef sig_t sighandler_t;
 #endif
 
 mongocxx::instance mongodb_instance;
-mongocxx::pool mongodb_pool{mongocxx::uri{"mongodb://192.168.1.11:27017"}};
+mongocxx::pool mongodb_pool{mongocxx::uri{"mongodb://127.0.0.1:27017"}};
 
 //bool rescue_mode=false;
 //std::string rescue_mode_cause;

--- a/src/whitelist.h
+++ b/src/whitelist.h
@@ -157,8 +157,11 @@ namespace FBWhitelist {
 		DBValue<NEMCUserAuthInfo> nemc_binded_account;
 		DBValue<std::string> phoenix_login_otp;
 		DBValue<bool> disable_all_security_measures;
+		DBValue<std::string> DotCS_User_Name;
+		DBValue<bool> isDotCS;
 		std::shared_ptr<uint32_t> rate_limit_counter;
 		std::shared_ptr<bool> keep_reference;
+
 		
 		DBValue<bool> *begin();
 		DBValue<bool> *end();


### PR DESCRIPTION
账户转移:
受到影响的数据:
FB用户名
增加的判定:
是否绑定dotcs与
dotcs用户名。
接口的改动:
登录fb用户中心:
1.增加一个以dotcs账户登录
2.fb账户登录加判定(绑定了dotcs的禁止登录)

用户信息:
1.登录了dotcs的账户获取的卡槽来源改成dotcs服务器
2.登录了dotcs的账户禁用频道机器人
3.登录了dotcs的账户禁用卡槽修改
4.用户信息部分增加2个字段来决定是否显示(FB用户中心中)

客户端登录:
1.禁止绑定了dotcs的账户登录fastBuilder客户端
2.增加一个针对dotcs客户端的验证接口。

转移页面:
尚未编写接口,改动会获取的fb的唯一信息:fb用户名以及使用fb验证服务器登录dotcs账户时的信息(租赁服号,租赁服密码,dotcs-token,客户端ip地址)。

补充:
dotcsClient 字段的ip地址是开发时的测试地址,实际使用非192.168.1.11:21512.
此外 dotcsClient 在未设置的正确的地址的情况下是不能使用的。(使用了也会提示无法连接到dotcs)